### PR TITLE
Set homepage in gemspec to libddwaf-rb repository

### DIFF
--- a/libddwaf.gemspec
+++ b/libddwaf.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     libddwaf packages a WAF implementation in C++, exposed to Ruby
   EOS
 
-  spec.homepage = 'https://github.com/DataDog/libddwaf'
+  spec.homepage = 'https://github.com/DataDog/libddwaf-rb'
   spec.license  = 'BSD-3-Clause'
 
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
Since <https://github.com/DataDog/libddwaf-rb> is where the Ruby code is, I think it makes sense to have it as the `homepage` in the gemspec.

Interested customers can always follow the link to the upstream libddwaf in the README.md.