### PR TITLE
set correct max string length when running

### DIFF
--- a/lib/datadog/appsec/waf.rb
+++ b/lib/datadog/appsec/waf.rb
@@ -627,7 +627,7 @@ module Datadog
 
           max_container_size  = LibDDWAF::DDWAF_MAX_CONTAINER_SIZE
           max_container_depth = LibDDWAF::DDWAF_MAX_CONTAINER_DEPTH
-          max_string_length   = LibDDWAF::DDWAF_MAX_CONTAINER_SIZE
+          max_string_length   = LibDDWAF::DDWAF_MAX_STRING_LENGTH
 
           input_obj = Datadog::AppSec::WAF.ruby_to_object(input,
                                                           max_container_size: max_container_size,


### PR DESCRIPTION
When parsing the input we were not using the right constant when calling `ruby_to_object`. The constant previously used was `DDWAF_MAX_CONTAINER_SIZE` which is 256. That value was use as the max length a string could be. 

That was causing issues with long input types.

Fix: Use the right constant `DDWAF_MAX_STRING_LENGTH` with a value of 4096