### PR TITLE
Work around Steep parsing

### DIFF
--- a/lib/datadog/appsec/waf.rb
+++ b/lib/datadog/appsec/waf.rb
@@ -203,8 +203,8 @@ module Datadog
           end
 
           class Obfuscator < ::FFI::Struct
-            layout :key_regex,   :pointer, # :charptr
-                   :value_regex, :pointer  # :charptr
+            layout :key_regex,   :pointer, # should be :charptr
+                   :value_regex, :pointer  # should be :charptr
           end
 
           layout :limits,     Limits,


### PR DESCRIPTION
Steep tries to understand this comment as a typing directive. Padding with more text to cue it into not doing that.