### PR TITLE
[APPSEC-7802] Release v1.6.2.0.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,5 @@
 inherit_from: .rubocop_todo.yml
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/datadog/appsec/waf_spec.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2023-02-03 v1.6.2.0.0
+
+- Update to libddwaf 1.6.2
+
 # 2023-02-01 v1.5.1.0.1
 
 - Fix incorrect size in input string limit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2023-02-03 v1.6.2.0.0
 
 - Update to libddwaf 1.6.2
+- Add specs for the getter functions
 
 # 2023-02-01 v1.5.1.0.1
 

--- a/Rakefile
+++ b/Rakefile
@@ -325,6 +325,11 @@ task :fetch, [:platform] => [] do |_, args|
     'libddwaf-1.5.1-darwin-x86_64.tar.gz' => '17052d22a29853edad9d064edfc4e9978a4f32d4d9c7d6f62d7e0bab3a775845',
     'libddwaf-1.5.1-linux-aarch64.tar.gz' => '73b18be793ba2efcae7b7a43c5e7c3ed94a0b2bbb7c56b177ca698c4a378fbd6',
     'libddwaf-1.5.1-linux-x86_64.tar.gz'  => '782f5c0cff725d5afbbea2a255a2690397a8d85cff0199626ff5f0197d6813ee',
+
+    'libddwaf-1.6.2-darwin-arm64.tar.gz'  => 'e0a990b9d62aae46d0cf726fdb77550e42e95bb04660d8c0099fd42356fb251c',
+    'libddwaf-1.6.2-darwin-x86_64.tar.gz' => '6c29cc7729fd04821e19cecfa9bd5180d863baeb44a12a24ea2aa3a6d06c39c6',
+    'libddwaf-1.6.2-linux-aarch64.tar.gz' => 'db08e8c7f3e949e17c57934efa3ac10c9241ab4786b4ba2996c24df58f7cb3f0',
+    'libddwaf-1.6.2-linux-x86_64.tar.gz'  => 'a667df7c9a7ae36ab6eecf759845abdb4dcc8ebb593a43af0698eb70aa9f89ca',
   }
 
   filename = Helpers.libddwaf_filename(platform: platform)

--- a/lib/datadog/appsec/waf.rb
+++ b/lib/datadog/appsec/waf.rb
@@ -182,6 +182,7 @@ module Datadog
         attach_function :ddwaf_object_get_unsigned, [:ddwaf_object], :uint64
         attach_function :ddwaf_object_get_signed, [:ddwaf_object], :int64
         attach_function :ddwaf_object_get_index, [:ddwaf_object, :size_t], :ddwaf_object
+        attach_function :ddwaf_object_get_bool, [:ddwaf_object], :bool
 
         ## freeers
 

--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -2,8 +2,8 @@ module Datadog
   module AppSec
     module WAF
       module VERSION
-        BASE_STRING = '1.5.1'
-        STRING = "#{BASE_STRING}.0.1"
+        BASE_STRING = '1.6.2'
+        STRING = "#{BASE_STRING}.0.0"
         MINIMUM_RUBY_VERSION = '2.1'
       end
     end

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -74,6 +74,7 @@ module Datadog
         def self.ddwaf_object_get_unsigned: (LibDDWAF::Object, SizeTPtr) -> ::Integer
         def self.ddwaf_object_get_signed: (LibDDWAF::Object, SizeTPtr) -> ::Integer
         def self.ddwaf_object_get_index: (LibDDWAF::Object, ::Integer) -> LibDDWAF::Object
+        def self.ddwaf_object_get_bool: (LibDDWAF::Object) -> bool
 
         # freeers
 

--- a/spec/datadog/appsec/waf_spec.rb
+++ b/spec/datadog/appsec/waf_spec.rb
@@ -1644,12 +1644,12 @@ RSpec.describe Datadog::AppSec::WAF do
             { 1 => 1, 'server.request.headers.no_cookies' => { 2 => 2, 'user-agent' => { 4 => 'Nessus SOAP' } } }
           end
 
-          it 'matches input inside of limit' do
+          it 'passes input inside of limit' do
             code, result = context.run(matching_input, timeout)
             perf_store[:total_runtime] << result.total_runtime
-            expect(code).to eq :match
-            expect(result.status).to eq :match
-            expect(result.data).to be_a Array
+            expect(code).to eq :ok
+            expect(result.status).to eq :ok
+            expect(result.data).to be nil
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
             expect(result.actions).to eq []

--- a/spec/datadog/appsec/waf_spec.rb
+++ b/spec/datadog/appsec/waf_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'datadog/appsec/waf'
 require 'json'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
   let(:libddwaf) { Datadog::AppSec::WAF::LibDDWAF }
 
@@ -231,6 +232,260 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
         expect(o[:valueUnion][:stringValue].read_bytes(o[:nbEntries])).to eq(i.to_s)
       end
       libddwaf.ddwaf_object_free(object)
+    end
+
+    context 'getters' do
+      let(:object_for_getter_spec) { libddwaf::Object.new }
+
+      after do
+        libddwaf.ddwaf_object_free(object_for_getter_spec)
+      end
+
+      describe '.ddwaf_object_type' do
+        [
+          ['for array object', :ddwaf_object_array, nil, :ddwaf_obj_array],
+          ['for map object', :ddwaf_object_map, nil, :ddwaf_obj_map],
+          ['for signed object', :ddwaf_object_signed_force, -12, :ddwaf_obj_signed,],
+          ['for unsigened object', :ddwaf_object_unsigned_force, 12, :ddwaf_obj_unsigned],
+          ['for string object', :ddwaf_object_string, "Hello World", :ddwaf_obj_string],
+          ['for boolean object', :ddwaf_object_bool, true, :ddwaf_obj_bool]
+        ].each do |message, method, value, result|
+          context message do
+            it 'returns object type' do
+              if value
+                libddwaf.send(method, object_for_getter_spec, value)
+              else
+                libddwaf.send(method, object_for_getter_spec)
+              end
+              object_type = libddwaf.ddwaf_object_type(object_for_getter_spec)
+              expect(object_type).to eq(result)
+            end
+          end
+        end
+      end
+
+      describe '.ddwaf_object_size' do
+        context 'for array object' do
+          it 'returns size' do
+            libddwaf.ddwaf_object_array(object_for_getter_spec)
+            member_object = libddwaf::Object.new
+            libddwaf.ddwaf_object_string(member_object, 'Hello World')
+            libddwaf.ddwaf_object_array_add(object_for_getter_spec, member_object)
+
+            size = libddwaf.ddwaf_object_size(object_for_getter_spec)
+            expect(size).to eq(1)
+          end
+        end
+
+        context 'for map object' do
+          it 'returns size' do
+            key = 'foo'
+            libddwaf.ddwaf_object_map(object_for_getter_spec)
+            member_object = libddwaf::Object.new
+            libddwaf.ddwaf_object_string(member_object, 'bar')
+            libddwaf.ddwaf_object_map_addl(object_for_getter_spec, key, key.bytesize, member_object)
+
+            size = libddwaf.ddwaf_object_size(object_for_getter_spec)
+            expect(size).to eq(1)
+          end
+        end
+
+        context 'for non container objects' do
+          it 'returns 0' do
+            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
+            size = libddwaf.ddwaf_object_size(object_for_getter_spec)
+            expect(size).to eq(0)
+          end
+        end
+      end
+
+      describe '.ddwaf_object_get_string' do
+        context 'for string object' do
+          it 'returns string' do
+            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
+            string = libddwaf.ddwaf_object_get_string(object_for_getter_spec, libddwaf::SizeTPtr.new)
+            expect(string.get_string(0)).to eq('Hello World')
+          end
+        end
+
+        context 'non string object' do
+          it 'returns null' do
+            libddwaf.ddwaf_object_map(object_for_getter_spec)
+            string = libddwaf.ddwaf_object_get_string(object_for_getter_spec, libddwaf::SizeTPtr.new)
+            expect(string).to be_null
+          end
+        end
+      end
+
+      describe '.ddwaf_object_get_index' do
+        context 'for map object' do
+          before do
+            key = 'foo'
+            libddwaf.ddwaf_object_map(object_for_getter_spec)
+            member_object = libddwaf::Object.new
+            libddwaf.ddwaf_object_string(member_object, 'bar')
+            libddwaf.ddwaf_object_map_addl(object_for_getter_spec, key, key.bytesize, member_object)
+          end
+
+          context 'with index in range' do
+            it 'returns object' do
+              object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 0)
+              expect(object).to_not be_null
+            end
+          end
+
+          context 'with index out of range' do
+            it 'returns null' do
+              object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 1)
+              expect(object).to be_null
+            end
+          end
+        end
+
+        context 'for array object' do
+          before do
+            libddwaf.ddwaf_object_array(object_for_getter_spec)
+            member_object = libddwaf::Object.new
+            libddwaf.ddwaf_object_string(member_object, 'Hello World')
+            libddwaf.ddwaf_object_array_add(object_for_getter_spec, member_object)
+          end
+
+          context 'with index in range' do
+            it 'returns object' do
+              object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 0)
+              expect(object).to_not be_null
+            end
+          end
+
+          context 'with index out of range' do
+            it 'returns null' do
+              object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 1)
+              expect(object).to be_null
+            end
+          end
+        end
+
+        context 'non container object' do
+          it 'returns null' do
+            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
+            object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 0)
+            expect(object).to be_null
+          end
+        end
+      end
+
+      describe '.ddwaf_object_get_key' do
+        context 'for map object' do
+          it 'returns object key' do
+            key = 'foo'
+            libddwaf.ddwaf_object_map(object_for_getter_spec)
+            member_object = libddwaf::Object.new
+            libddwaf.ddwaf_object_string(member_object, 'bar')
+            libddwaf.ddwaf_object_map_addl(object_for_getter_spec, key, key.bytesize, member_object)
+
+            object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 0)
+            key_object = libddwaf.ddwaf_object_get_key(object, libddwaf::SizeTPtr.new)
+
+            expect(key_object.get_string(0)).to eq('foo')
+          end
+
+          it 'returns key length' do
+            key = 'foo'
+            libddwaf.ddwaf_object_map(object_for_getter_spec)
+            member_object = libddwaf::Object.new
+            libddwaf.ddwaf_object_string(member_object, 'bar')
+            libddwaf.ddwaf_object_map_addl(object_for_getter_spec, key, key.bytesize, member_object)
+
+            object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 0)
+            length = libddwaf::SizeTPtr.new
+
+            expect(length.pointer.get_int(0)).to eq(0)
+            libddwaf.ddwaf_object_get_key(object, length)
+            expect(length.pointer.get_int(0)).to eq(3)
+          end
+
+          context 'for non map object' do
+            it 'returns nulls' do
+              libddwaf.ddwaf_object_string(object_for_getter_spec, 'bar')
+              key_object = libddwaf.ddwaf_object_get_key(object_for_getter_spec, libddwaf::SizeTPtr.new)
+
+              expect(key_object).to be_null
+            end
+          end
+        end
+
+        context 'non map objects' do
+          it 'returns nulll' do
+            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
+            object = libddwaf.ddwaf_object_get_key(object_for_getter_spec, libddwaf::SizeTPtr.new)
+            expect(object).to be_null
+          end
+        end
+      end
+
+      describe '.ddwaf_object_get_signed' do
+        context 'for signed object' do
+          it 'returns value' do
+            libddwaf.ddwaf_object_signed_force(object_for_getter_spec, -12)
+            value = libddwaf.ddwaf_object_get_signed(object_for_getter_spec)
+            expect(value).to eq(-12)
+          end
+        end
+
+        context 'for non signed object' do
+          it 'returns 0' do
+            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
+            value = libddwaf.ddwaf_object_get_signed(object_for_getter_spec)
+            expect(value).to eq(0)
+          end
+        end
+      end
+
+      describe '.ddwaf_object_get_unsigned' do
+        context 'for unsigned object' do
+          it 'returns value' do
+            libddwaf.ddwaf_object_unsigned_force(object_for_getter_spec, 12)
+            value = libddwaf.ddwaf_object_get_unsigned(object_for_getter_spec)
+            expect(value).to eq(12)
+          end
+        end
+
+        context 'for non unsigned object' do
+          it 'returns 0' do
+            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
+            value = libddwaf.ddwaf_object_get_unsigned(object_for_getter_spec)
+            expect(value).to eq(0)
+          end
+        end
+      end
+
+      describe '.ddwaf_object_get_bool' do
+        context 'for boolean object' do
+          context 'true' do
+            it 'returns value' do
+              libddwaf.ddwaf_object_bool(object_for_getter_spec, true)
+              value = libddwaf.ddwaf_object_get_bool(object_for_getter_spec)
+              expect(value).to eq(true)
+            end
+          end
+
+          context 'false' do
+            it 'returns value' do
+              libddwaf.ddwaf_object_bool(object_for_getter_spec, false)
+              value = libddwaf.ddwaf_object_get_bool(object_for_getter_spec)
+              expect(value).to eq(false)
+            end
+          end
+        end
+
+        context 'for non boolean object' do
+          it 'returns false' do
+            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
+            value = libddwaf.ddwaf_object_get_bool(object_for_getter_spec)
+            expect(value).to eq(false)
+          end
+        end
+      end
     end
   end
 
@@ -2076,3 +2331,4 @@ RSpec.describe Datadog::AppSec::WAF do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/datadog/appsec/waf_spec.rb
+++ b/spec/datadog/appsec/waf_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'datadog/appsec/waf'
 require 'json'
 
-# rubocop:disable Metrics/BlockLength
 RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
   let(:libddwaf) { Datadog::AppSec::WAF::LibDDWAF }
 
@@ -2331,4 +2330,3 @@ RSpec.describe Datadog::AppSec::WAF do
     end
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/spec/datadog/appsec/waf_spec.rb
+++ b/spec/datadog/appsec/waf_spec.rb
@@ -234,10 +234,10 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
     end
 
     context 'getters' do
-      let(:object_for_getter_spec) { libddwaf::Object.new }
+      let(:ddwaf_object) { libddwaf::Object.new }
 
       after do
-        libddwaf.ddwaf_object_free(object_for_getter_spec)
+        libddwaf.ddwaf_object_free(ddwaf_object)
       end
 
       describe '.ddwaf_object_type' do
@@ -248,16 +248,16 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
           ['for unsigened object', :ddwaf_object_unsigned_force, 12, :ddwaf_obj_unsigned],
           ['for string object', :ddwaf_object_string, "Hello World", :ddwaf_obj_string],
           ['for boolean object', :ddwaf_object_bool, true, :ddwaf_obj_bool]
-        ].each do |message, method, value, result|
+        ].each do |message, method, value, expected_object_type|
           context message do
-            it 'returns object type' do
+            it "returns object type #{expected_object_type.inspect}" do
               if value
-                libddwaf.send(method, object_for_getter_spec, value)
+                libddwaf.send(method, ddwaf_object, value)
               else
-                libddwaf.send(method, object_for_getter_spec)
+                libddwaf.send(method, ddwaf_object)
               end
-              object_type = libddwaf.ddwaf_object_type(object_for_getter_spec)
-              expect(object_type).to eq(result)
+              object_type = libddwaf.ddwaf_object_type(ddwaf_object)
+              expect(object_type).to eq(expected_object_type)
             end
           end
         end
@@ -266,12 +266,12 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
       describe '.ddwaf_object_size' do
         context 'for array object' do
           it 'returns size' do
-            libddwaf.ddwaf_object_array(object_for_getter_spec)
+            libddwaf.ddwaf_object_array(ddwaf_object)
             member_object = libddwaf::Object.new
             libddwaf.ddwaf_object_string(member_object, 'Hello World')
-            libddwaf.ddwaf_object_array_add(object_for_getter_spec, member_object)
+            libddwaf.ddwaf_object_array_add(ddwaf_object, member_object)
 
-            size = libddwaf.ddwaf_object_size(object_for_getter_spec)
+            size = libddwaf.ddwaf_object_size(ddwaf_object)
             expect(size).to eq(1)
           end
         end
@@ -279,20 +279,20 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
         context 'for map object' do
           it 'returns size' do
             key = 'foo'
-            libddwaf.ddwaf_object_map(object_for_getter_spec)
+            libddwaf.ddwaf_object_map(ddwaf_object)
             member_object = libddwaf::Object.new
             libddwaf.ddwaf_object_string(member_object, 'bar')
-            libddwaf.ddwaf_object_map_addl(object_for_getter_spec, key, key.bytesize, member_object)
+            libddwaf.ddwaf_object_map_addl(ddwaf_object, key, key.bytesize, member_object)
 
-            size = libddwaf.ddwaf_object_size(object_for_getter_spec)
+            size = libddwaf.ddwaf_object_size(ddwaf_object)
             expect(size).to eq(1)
           end
         end
 
         context 'for non container objects' do
           it 'returns 0' do
-            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
-            size = libddwaf.ddwaf_object_size(object_for_getter_spec)
+            libddwaf.ddwaf_object_string(ddwaf_object, 'Hello World')
+            size = libddwaf.ddwaf_object_size(ddwaf_object)
             expect(size).to eq(0)
           end
         end
@@ -301,16 +301,16 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
       describe '.ddwaf_object_get_string' do
         context 'for string object' do
           it 'returns string' do
-            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
-            string = libddwaf.ddwaf_object_get_string(object_for_getter_spec, libddwaf::SizeTPtr.new)
+            libddwaf.ddwaf_object_string(ddwaf_object, 'Hello World')
+            string = libddwaf.ddwaf_object_get_string(ddwaf_object, libddwaf::SizeTPtr.new)
             expect(string.get_string(0)).to eq('Hello World')
           end
         end
 
         context 'non string object' do
           it 'returns null' do
-            libddwaf.ddwaf_object_map(object_for_getter_spec)
-            string = libddwaf.ddwaf_object_get_string(object_for_getter_spec, libddwaf::SizeTPtr.new)
+            libddwaf.ddwaf_object_map(ddwaf_object)
+            string = libddwaf.ddwaf_object_get_string(ddwaf_object, libddwaf::SizeTPtr.new)
             expect(string).to be_null
           end
         end
@@ -320,22 +320,22 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
         context 'for map object' do
           before do
             key = 'foo'
-            libddwaf.ddwaf_object_map(object_for_getter_spec)
+            libddwaf.ddwaf_object_map(ddwaf_object)
             member_object = libddwaf::Object.new
             libddwaf.ddwaf_object_string(member_object, 'bar')
-            libddwaf.ddwaf_object_map_addl(object_for_getter_spec, key, key.bytesize, member_object)
+            libddwaf.ddwaf_object_map_addl(ddwaf_object, key, key.bytesize, member_object)
           end
 
           context 'with index in range' do
             it 'returns object' do
-              object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 0)
+              object = libddwaf.ddwaf_object_get_index(ddwaf_object, 0)
               expect(object).to_not be_null
             end
           end
 
           context 'with index out of range' do
             it 'returns null' do
-              object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 1)
+              object = libddwaf.ddwaf_object_get_index(ddwaf_object, 1)
               expect(object).to be_null
             end
           end
@@ -343,22 +343,22 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
 
         context 'for array object' do
           before do
-            libddwaf.ddwaf_object_array(object_for_getter_spec)
+            libddwaf.ddwaf_object_array(ddwaf_object)
             member_object = libddwaf::Object.new
             libddwaf.ddwaf_object_string(member_object, 'Hello World')
-            libddwaf.ddwaf_object_array_add(object_for_getter_spec, member_object)
+            libddwaf.ddwaf_object_array_add(ddwaf_object, member_object)
           end
 
           context 'with index in range' do
             it 'returns object' do
-              object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 0)
+              object = libddwaf.ddwaf_object_get_index(ddwaf_object, 0)
               expect(object).to_not be_null
             end
           end
 
           context 'with index out of range' do
             it 'returns null' do
-              object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 1)
+              object = libddwaf.ddwaf_object_get_index(ddwaf_object, 1)
               expect(object).to be_null
             end
           end
@@ -366,8 +366,8 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
 
         context 'non container object' do
           it 'returns null' do
-            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
-            object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 0)
+            libddwaf.ddwaf_object_string(ddwaf_object, 'Hello World')
+            object = libddwaf.ddwaf_object_get_index(ddwaf_object, 0)
             expect(object).to be_null
           end
         end
@@ -377,12 +377,12 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
         context 'for map object' do
           it 'returns object key' do
             key = 'foo'
-            libddwaf.ddwaf_object_map(object_for_getter_spec)
+            libddwaf.ddwaf_object_map(ddwaf_object)
             member_object = libddwaf::Object.new
             libddwaf.ddwaf_object_string(member_object, 'bar')
-            libddwaf.ddwaf_object_map_addl(object_for_getter_spec, key, key.bytesize, member_object)
+            libddwaf.ddwaf_object_map_addl(ddwaf_object, key, key.bytesize, member_object)
 
-            object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 0)
+            object = libddwaf.ddwaf_object_get_index(ddwaf_object, 0)
             key_object = libddwaf.ddwaf_object_get_key(object, libddwaf::SizeTPtr.new)
 
             expect(key_object.get_string(0)).to eq('foo')
@@ -390,12 +390,12 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
 
           it 'returns key length' do
             key = 'foo'
-            libddwaf.ddwaf_object_map(object_for_getter_spec)
+            libddwaf.ddwaf_object_map(ddwaf_object)
             member_object = libddwaf::Object.new
             libddwaf.ddwaf_object_string(member_object, 'bar')
-            libddwaf.ddwaf_object_map_addl(object_for_getter_spec, key, key.bytesize, member_object)
+            libddwaf.ddwaf_object_map_addl(ddwaf_object, key, key.bytesize, member_object)
 
-            object = libddwaf.ddwaf_object_get_index(object_for_getter_spec, 0)
+            object = libddwaf.ddwaf_object_get_index(ddwaf_object, 0)
             length = libddwaf::SizeTPtr.new
 
             expect(length.pointer.get_int(0)).to eq(0)
@@ -405,8 +405,8 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
 
           context 'for non map object' do
             it 'returns nulls' do
-              libddwaf.ddwaf_object_string(object_for_getter_spec, 'bar')
-              key_object = libddwaf.ddwaf_object_get_key(object_for_getter_spec, libddwaf::SizeTPtr.new)
+              libddwaf.ddwaf_object_string(ddwaf_object, 'bar')
+              key_object = libddwaf.ddwaf_object_get_key(ddwaf_object, libddwaf::SizeTPtr.new)
 
               expect(key_object).to be_null
             end
@@ -415,8 +415,8 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
 
         context 'non map objects' do
           it 'returns nulll' do
-            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
-            object = libddwaf.ddwaf_object_get_key(object_for_getter_spec, libddwaf::SizeTPtr.new)
+            libddwaf.ddwaf_object_string(ddwaf_object, 'Hello World')
+            object = libddwaf.ddwaf_object_get_key(ddwaf_object, libddwaf::SizeTPtr.new)
             expect(object).to be_null
           end
         end
@@ -425,16 +425,16 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
       describe '.ddwaf_object_get_signed' do
         context 'for signed object' do
           it 'returns value' do
-            libddwaf.ddwaf_object_signed_force(object_for_getter_spec, -12)
-            value = libddwaf.ddwaf_object_get_signed(object_for_getter_spec)
+            libddwaf.ddwaf_object_signed_force(ddwaf_object, -12)
+            value = libddwaf.ddwaf_object_get_signed(ddwaf_object)
             expect(value).to eq(-12)
           end
         end
 
         context 'for non signed object' do
           it 'returns 0' do
-            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
-            value = libddwaf.ddwaf_object_get_signed(object_for_getter_spec)
+            libddwaf.ddwaf_object_string(ddwaf_object, 'Hello World')
+            value = libddwaf.ddwaf_object_get_signed(ddwaf_object)
             expect(value).to eq(0)
           end
         end
@@ -443,16 +443,16 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
       describe '.ddwaf_object_get_unsigned' do
         context 'for unsigned object' do
           it 'returns value' do
-            libddwaf.ddwaf_object_unsigned_force(object_for_getter_spec, 12)
-            value = libddwaf.ddwaf_object_get_unsigned(object_for_getter_spec)
+            libddwaf.ddwaf_object_unsigned_force(ddwaf_object, 12)
+            value = libddwaf.ddwaf_object_get_unsigned(ddwaf_object)
             expect(value).to eq(12)
           end
         end
 
         context 'for non unsigned object' do
           it 'returns 0' do
-            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
-            value = libddwaf.ddwaf_object_get_unsigned(object_for_getter_spec)
+            libddwaf.ddwaf_object_string(ddwaf_object, 'Hello World')
+            value = libddwaf.ddwaf_object_get_unsigned(ddwaf_object)
             expect(value).to eq(0)
           end
         end
@@ -462,16 +462,16 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
         context 'for boolean object' do
           context 'true' do
             it 'returns value' do
-              libddwaf.ddwaf_object_bool(object_for_getter_spec, true)
-              value = libddwaf.ddwaf_object_get_bool(object_for_getter_spec)
+              libddwaf.ddwaf_object_bool(ddwaf_object, true)
+              value = libddwaf.ddwaf_object_get_bool(ddwaf_object)
               expect(value).to eq(true)
             end
           end
 
           context 'false' do
             it 'returns value' do
-              libddwaf.ddwaf_object_bool(object_for_getter_spec, false)
-              value = libddwaf.ddwaf_object_get_bool(object_for_getter_spec)
+              libddwaf.ddwaf_object_bool(ddwaf_object, false)
+              value = libddwaf.ddwaf_object_get_bool(ddwaf_object)
               expect(value).to eq(false)
             end
           end
@@ -479,8 +479,8 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
 
         context 'for non boolean object' do
           it 'returns false' do
-            libddwaf.ddwaf_object_string(object_for_getter_spec, 'Hello World')
-            value = libddwaf.ddwaf_object_get_bool(object_for_getter_spec)
+            libddwaf.ddwaf_object_string(ddwaf_object, 'Hello World')
+            value = libddwaf.ddwaf_object_get_bool(ddwaf_object)
             expect(value).to eq(false)
           end
         end
@@ -1923,7 +1923,7 @@ RSpec.describe Datadog::AppSec::WAF do
             { 'server.request.headers.no_cookies' => { 'user-agent' => ['Nessus SOAP'] } }
           end
 
-          it 'passes' do
+          it 'passes on matching input outside of limit' do
             code, result = context.run(matching_input, timeout)
             perf_store[:total_runtime] << result.total_runtime
             expect(code).to eq :ok
@@ -1942,7 +1942,7 @@ RSpec.describe Datadog::AppSec::WAF do
             { 'server.request.headers.no_cookies' => { 'user-agent' => 'Nessus SOAP' } }
           end
 
-          it 'matches' do
+          it 'matches on matching input inside of limit' do
             code, result = context.run(matching_input, timeout)
             perf_store[:total_runtime] << result.total_runtime
             expect(code).to eq :match


### PR DESCRIPTION
Base on the latest release from libddwaf 1.6.2 . Only one new function has been added to the library `ddwaf_object_get_bool`

Compare between previous version [1.5.1 and 1.6.2](https://github.com/DataDog/libddwaf/compare/1.5.1...1.6.2#diff-b237790755a7680c602d8e294ac9fa8efd9d94f834e52db8be31410d727f1dd0R634)


libddwaf updated the logic when filtering input https://github.com/DataDog/libddwaf/pull/117. Because of that I had to modify a test in the codebase.