### PR TITLE
Add a basic `shell.nix`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ Gemfile.lock
 /.envrc
 /vendor/bundle
 /vendor/libddwaf
-/*.nix
 /pkg
 *.gem
 *.vim

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,35 @@
+{
+  # use the environment channel
+  pkgs ? import <nixpkgs> {},
+
+  # use a pinned package state
+  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/14d9b465c71.tar.gz")) {},
+}:
+let
+  # specify ruby version to use
+  ruby = pinned.ruby_3_1;
+
+  # control llvm/clang version (e.g for packages built form source)
+  llvm = pinned.llvmPackages_12;
+in llvm.stdenv.mkDerivation {
+  # unique project name for this environment derivation
+  name = "libddwaf-rb.devshell";
+
+  buildInputs = [
+    ruby
+  ];
+
+  shellHook = ''
+    # get major.minor.0 ruby version
+    export RUBY_VERSION="$(ruby -e 'puts RUBY_VERSION.gsub(/\d+$/, "0")')"
+
+    # make gem install work in-project, compatibly with bundler
+    export GEM_HOME="$(pwd)/vendor/bundle/ruby/$RUBY_VERSION"
+
+    # make bundle work in-project
+    export BUNDLE_PATH="$(pwd)/vendor/bundle"
+
+    # enable calling gem scripts without bundle exec
+    export PATH="$GEM_HOME/bin:$PATH"
+  '';
+}


### PR DESCRIPTION
## Description

Add a `shell.nix` file

This is entirely optional to use but for nixpkgs users this is a really
easy way to get things up and running. With just:

```
nix-shell
```

All needed dependencies get automatically pulled in, dropping the
user in a ready-to-use shell.

Then as usual:

```
bundle install
```

Puts everything in a `vendor/bundle` directory, which behaves as usual regarding `gem install` and `bundle` in general. Should it need to be cleaned up, e.g to start form scratch,
a simple `rm -rf vendor/bundle` is sufficient.

Also, gem commands can typically be run with or without `bundle exec`.

It also pins to a specific commit for the channel, so that tool versions
are always consistent.