### PR TITLE
Include signature directory in binary gems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -495,6 +495,7 @@ task :binary, [:platform] => [] do |_, args|
 
   gemspec.files = []
   gemspec.files += Dir['lib/**/*.rb']
+  gemspec.files += Dir['sig/**/*.rbs']
   gemspec.files += ['NOTICE', 'CHANGELOG.md'] + Dir['LICENSE*']
 
   gemspec.files += shared_lib_paths


### PR DESCRIPTION
This should allow using `gem 'libddwaf'` from `ddtrace`, even with binary gems.