### PR TITLE
Upgrade libddwaf to 1.9.0. Add support for `custom_rules`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,4 +40,8 @@ gem 'yard', '~> 0.9'
 if RUBY_VERSION >= '2.6.0'
   gem 'rbs', '~> 2.8.1', require: false
   gem 'steep', '~> 1.3.0', require: false
+
+  # parallel 1.23 seems to annoy steep:
+  # cannot load such file -- parallel/processor_count (LoadError)
+  gem 'parallel', '< 1.23'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -340,6 +340,11 @@ task :fetch, [:platform] => [] do |_, args|
     'libddwaf-1.8.2-darwin-x86_64.tar.gz' => 'c1fbf821396c9ba62deeae9719aff9ecb6a904f77b7d68c95de4eb759fb646ac',
     'libddwaf-1.8.2-linux-aarch64.tar.gz' => 'fee446827b2971454be992fa99284fb5b5d2609dd2cefba4c331fa1b53bc7faf',
     'libddwaf-1.8.2-linux-x86_64.tar.gz'  => '106d5830b9011df1d7257d70ca1016a5970c8f287e75e0ad00d67e821c9ff04c',
+
+    'libddwaf-1.9.0-darwin-arm64.tar.gz'  => 'dbec69fbfd383266566f6bb2d9e033a88baab9bfc97b2ab552fbc22626b65b5a',
+    'libddwaf-1.9.0-darwin-x86_64.tar.gz' => 'fbb00c3dad779141ef037238315aab84adac5abfffb7944b19e5493d432ea43c',
+    'libddwaf-1.9.0-linux-aarch64.tar.gz' => '3869b807be750bc71359e1add277635afecc20ea8609e3fc4c0c9722a68b709f',
+    'libddwaf-1.9.0-linux-x86_64.tar.gz'  => 'a1e7422116d318883ad43942d7416bbe3e92797e60840336a98d1100487de912',
   }
 
   filename = Helpers.libddwaf_filename(platform: platform)

--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -2,7 +2,7 @@ module Datadog
   module AppSec
     module WAF
       module VERSION
-        BASE_STRING = '1.8.2'
+        BASE_STRING = '1.9.0'
         STRING = "#{BASE_STRING}.0.0"
         MINIMUM_RUBY_VERSION = '2.1'
       end

--- a/spec/datadog/appsec/waf_spec.rb
+++ b/spec/datadog/appsec/waf_spec.rb
@@ -1653,6 +1653,54 @@ RSpec.describe Datadog::AppSec::WAF do
     end
   end
 
+  context 'with a custom rules' do
+    let(:rule) do
+      {
+        'version' => '2.2',
+        'metadata' => {
+          'rules_version' => '1.2.3'
+        },
+        'rules' => [
+          {
+            'id' => 1,
+            'name' => 'Rule 1',
+            'tags' => { 'type' => 'flow1' },
+            'conditions' => [
+              {
+                'operator' => 'match_regex',
+                'parameters' => { 'inputs' => [{ 'address' => 'value2' }], 'regex' => 'rule1' }
+              },
+            ],
+            'action' => 'record',
+          }
+        ],
+        'custom_rules' => [
+          {
+            'id' => 3,
+            'name' => 'Custom Rule 1',
+            'tags' => { 'type' => 'custom_flow' },
+            'conditions' => [
+              {
+                'operator' => 'match_regex',
+                'parameters' => { 'inputs' => [{ 'address' => 'custom_address' }], 'regex' => 'custom_value' }
+              },
+            ],
+            'action' => 'record',
+          }
+        ]
+      }
+    end
+
+    let(:matching_input) do
+      { custom_address: ['custom_value'] }
+    end
+
+    it 'matches custom rule' do
+      code, = context.run(matching_input, timeout)
+      expect(code).to eq :match
+    end
+  end
+
   describe '#merge' do
     context 'valid merge data' do
       context 'rules override' do


### PR DESCRIPTION
Upgrade libddwaf to 1.9.0

Here is the diff between [1.82 and 1.9.0](https://github.com/DataDog/libddwaf/compare/1.8.2...1.9.0)

The biggest change for us, is that we can now pass `custom_rules` to WAF init and merege