### PR TITLE
[APPSEC-10967] Release 1.14.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,4 +30,4 @@ jobs:
           bundle install
       - name: Run Steep
         run: |
-          bundle exec steep check --severity-level=error
+          bundle exec steep check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,4 +30,4 @@ jobs:
           bundle install
       - name: Run Steep
         run: |
-          bundle exec steep check
+          bundle exec steep check --severity-level=error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 2023-09-11 v.1.14.0.0.0\
+# 2023-09-11 v.1.14.0.0.0
 - Update to libddwaf 1.14.0
-- Add support for `Float`` and `Nil`` scalar values when converting from ruby to WAF Object and vice versa.
+- Add support for `Float` and `Nil` scalar values when converting from ruby to WAF Object and vice versa.
 
 
 # 2023-08-29 v.1.11.0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2023-09-11 v.1.14.0.0.0\
+- Update to libddwaf 1.14.0
+- Add support for `Float`` and `Nil`` scalar values when converting from ruby to WAF Object and vice versa.
+
+
 # 2023-08-29 v.1.11.0.0.0
 
 - Update to libddwaf 1.11.0

--- a/Rakefile
+++ b/Rakefile
@@ -355,6 +355,11 @@ task :fetch, [:platform] => [] do |_, args|
     'libddwaf-1.11.0-darwin-x86_64.tar.gz' => 'e1285b9a62393a4a37fad16b49812052b9eed95920ffe4cd591e06ac27ed1b32',
     'libddwaf-1.11.0-linux-aarch64.tar.gz' => '92a0a64daa00376b127dfe7d7f02436f39a611325113e212cf2cdafddd50053a',
     'libddwaf-1.11.0-linux-x86_64.tar.gz'  => '7a0682c2e65cec7540d04646621d6768bc8f42c5ff22da2a0d20801b51ad442a',
+
+    'libddwaf-1.14.0-darwin-arm64.tar.gz'  => 'd9cd1c92a3a814b8f3c4f92f7dce3037904c2650fcff52019121b0a7c56a5106',
+    'libddwaf-1.14.0-darwin-x86_64.tar.gz' => '9bea4519fabd0d740ad45050654aef92b3c33ede2ea76e0c616adfb4b2aff828',
+    'libddwaf-1.14.0-linux-aarch64.tar.gz' => 'e54bd624459158c33f62c846399ccaf7ae851b039cb2daa727949ab5b1d50ff5',
+    'libddwaf-1.14.0-linux-x86_64.tar.gz'  => '0e56a381e81cbdf8d8375d42642ee31ac46e576c7e4ad9e72d0b7d214c0f9874',
   }
 
   filename = Helpers.libddwaf_filename(platform: platform)

--- a/Steepfile
+++ b/Steepfile
@@ -4,7 +4,6 @@ target :lib do
   signature "sig"
 
   check "lib"
-  library "rubygems"
   library "logger"
   library "monitor" # needed by logger
   library "json"

--- a/lib/datadog/appsec/waf.rb
+++ b/lib/datadog/appsec/waf.rb
@@ -575,14 +575,15 @@ module Datadog
       end
 
       class Result
-        attr_reader :status, :events, :total_runtime, :timeout, :actions
+        attr_reader :status, :events, :total_runtime, :timeout, :actions, :derivatives
 
-        def initialize(status, events, total_runtime, timeout, actions)
+        def initialize(status, events, total_runtime, timeout, actions, derivatives)
           @status = status
           @events = events
           @total_runtime = total_runtime
           @timeout = timeout
           @actions = actions
+          @derivatives = derivatives
         end
       end
 
@@ -623,7 +624,8 @@ module Datadog
           input_obj = Datadog::AppSec::WAF.ruby_to_object(input,
                                                           max_container_size: max_container_size,
                                                           max_container_depth: max_container_depth,
-                                                          max_string_length: max_string_length)
+                                                          max_string_length: max_string_length,
+                                                          coerce: false)
           if input_obj.null?
             fail LibDDWAF::Error, "Could not convert input: #{input.inspect}"
           end
@@ -644,6 +646,7 @@ module Datadog
             result_obj[:total_runtime],
             result_obj[:timeout],
             Datadog::AppSec::WAF.object_to_ruby(result_obj[:actions]),
+            Datadog::AppSec::WAF.object_to_ruby(result_obj[:derivatives]),
           )
 
           [RESULT_CODE[code], result]

--- a/lib/datadog/appsec/waf.rb
+++ b/lib/datadog/appsec/waf.rb
@@ -399,6 +399,18 @@ module Datadog
           end
 
           obj
+        when NilClass
+          obj = LibDDWAF::Object.new
+          res = if coerce
+                  LibDDWAF.ddwaf_object_string(obj, '')
+                else
+                  LibDDWAF.ddwaf_object_null(obj)
+                end
+          if res.null?
+            fail LibDDWAF::Error, "Could not convert into object: #{val.inspect}"
+          end
+
+          obj
         else
           ruby_to_object(''.freeze)
         end
@@ -407,7 +419,7 @@ module Datadog
 
       def self.object_to_ruby(obj)
         case obj[:type]
-        when :ddwaf_obj_invalid
+        when :ddwaf_obj_invalid, :ddwaf_obj_null
           nil
         when :ddwaf_obj_bool
           obj[:valueUnion][:boolean]

--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -2,7 +2,7 @@ module Datadog
   module AppSec
     module WAF
       module VERSION
-        BASE_STRING = '1.11.0'
+        BASE_STRING = '1.14.0'
         STRING = "#{BASE_STRING}.0.0"
         MINIMUM_RUBY_VERSION = '2.1'
       end

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -142,7 +142,7 @@ module Datadog
 
       def self.version: () -> ::String
 
-      type data = String | Symbol | Integer | Float | TrueClass | FalseClass | Array[data] | Hash[String | Symbol, data] | nil
+      type data = String | Symbol | Integer | Float | TrueClass | FalseClass | Array[data] | Hash[(String | Symbol | nil), data] | nil
 
       def self.ruby_to_object: (top val, ?max_container_size: ::Integer?, ?max_container_depth: ::Integer?, ?max_string_length: ::Integer?, ?coerce: bool?) -> ::Datadog::AppSec::WAF::LibDDWAF::Object
       def self.object_to_ruby: (::Datadog::AppSec::WAF::LibDDWAF::Object obj) -> data

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -52,9 +52,10 @@ module Datadog
         def self.ddwaf_object_stringl_nc: (LibDDWAF::Object, ::String, ::Integer) -> ::FFI::Pointer
         def self.ddwaf_object_unsigned: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
         def self.ddwaf_object_signed: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
-        def self.ddwaf_object_unsigned_force: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
-        def self.ddwaf_object_signed_force: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
+        def self.ddwaf_object_string_from_unsigned: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
+        def self.ddwaf_object_string_from_signed: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
         def self.ddwaf_object_bool: (LibDDWAF::Object, bool) -> ::FFI::Pointer
+        def self.ddwaf_object_float: (LibDDWAF::Object, ::Float) -> ::FFI::Pointer
 
         def self.ddwaf_object_array: (LibDDWAF::Object) -> ::FFI::Pointer
         def self.ddwaf_object_array_add: (LibDDWAF::Object, LibDDWAF::Object) -> bool
@@ -75,6 +76,7 @@ module Datadog
         def self.ddwaf_object_get_signed: (LibDDWAF::Object, SizeTPtr) -> ::Integer
         def self.ddwaf_object_get_index: (LibDDWAF::Object, ::Integer) -> LibDDWAF::Object
         def self.ddwaf_object_get_bool: (LibDDWAF::Object) -> bool
+        def self.ddwaf_object_get_float: (LibDDWAF::Object) -> ::Float
 
         # freeers
 

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -144,7 +144,7 @@ module Datadog
 
       type data = String | Symbol | Integer | Float | TrueClass | FalseClass | Array[data] | Hash[String | Symbol, data] | nil
 
-      def self.ruby_to_object: (data val, ?max_container_size: ::Integer?, ?max_container_depth: ::Integer?, ?max_string_length: ::Integer?, ?coerce: bool?) -> ::Datadog::AppSec::WAF::LibDDWAF::Object
+      def self.ruby_to_object: (top val, ?max_container_size: ::Integer?, ?max_container_depth: ::Integer?, ?max_string_length: ::Integer?, ?coerce: bool?) -> ::Datadog::AppSec::WAF::LibDDWAF::Object
       def self.object_to_ruby: (::Datadog::AppSec::WAF::LibDDWAF::Object obj) -> data
 
       self.@logger: ::Logger

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -56,6 +56,7 @@ module Datadog
         def self.ddwaf_object_string_from_signed: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
         def self.ddwaf_object_bool: (LibDDWAF::Object, bool) -> ::FFI::Pointer
         def self.ddwaf_object_float: (LibDDWAF::Object, ::Float) -> ::FFI::Pointer
+        def self.ddwaf_object_null: (LibDDWAF::Object) -> ::FFI::Pointer
 
         def self.ddwaf_object_array: (LibDDWAF::Object) -> ::FFI::Pointer
         def self.ddwaf_object_array_add: (LibDDWAF::Object, LibDDWAF::Object) -> bool

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -182,8 +182,9 @@ module Datadog
         attr_reader total_runtime: ::Float
         attr_reader timeout: bool
         attr_reader actions: data
+        attr_reader derivatives: data
 
-        def initialize: (::Symbol, data, ::Float, bool, data) -> void
+        def initialize: (::Symbol, data, ::Float, bool, data, data) -> void
       end
 
       class Context

--- a/spec/datadog/appsec/waf_spec.rb
+++ b/spec/datadog/appsec/waf_spec.rb
@@ -507,7 +507,7 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
   end
 
   context 'ruby_to_object' do
-    context 'with coerction to string' do
+    context 'with coercion to string' do
       it 'converts nil' do
         obj = Datadog::AppSec::WAF.ruby_to_object(nil)
         expect(obj[:type]).to eq :ddwaf_obj_string
@@ -785,12 +785,9 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
 
     context 'without coercion to string' do
       it 'converts nil' do
-        # TODO: coerced because of arrays and maps
-
         obj = Datadog::AppSec::WAF.ruby_to_object(nil, coerce: false)
-        expect(obj[:type]).to eq :ddwaf_obj_string
+        expect(obj[:type]).to eq :ddwaf_obj_null
         expect(obj[:nbEntries]).to eq 0
-        expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq ''
       end
 
       it 'converts an unhandled object' do
@@ -1064,6 +1061,11 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
     it 'converts a string' do
       obj = Datadog::AppSec::WAF.ruby_to_object('foo')
       expect(Datadog::AppSec::WAF.object_to_ruby(obj)).to eq('foo')
+    end
+
+    it 'converts a nil' do
+      obj = Datadog::AppSec::WAF.ruby_to_object(nil, coerce: false)
+      expect(Datadog::AppSec::WAF.object_to_ruby(obj)).to be_nil
     end
 
     it 'converts an array' do

--- a/spec/datadog/appsec/waf_spec.rb
+++ b/spec/datadog/appsec/waf_spec.rb
@@ -1963,7 +1963,7 @@ RSpec.describe Datadog::AppSec::WAF do
       expect(result.total_runtime).to be > 0
       expect(result.timeout).to eq false
       expect(result.actions).to eq []
-      expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_rule}/ }).to_not be_nil
+      expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
       expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
     end
 
@@ -1977,7 +1977,7 @@ RSpec.describe Datadog::AppSec::WAF do
       expect(result.timeout).to eq false
       expect(result.actions).to eq []
       expect(result.events.find { |r| r['rule']['id'] == matching_input_rule }).to_not be_nil
-      expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_rule}/ }).to_not be_nil
+      expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
       expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
     end
 
@@ -2001,7 +2001,8 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
             expect(result.actions).to eq []
-            expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_rule}/ }).to_not be_nil
+
+            expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
           end
         end
@@ -2020,7 +2021,8 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
             expect(result.actions).to eq []
-            expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_rule}/ }).to_not be_nil
+
+            expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
           end
         end
@@ -2039,7 +2041,8 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
             expect(result.actions).to eq []
-            expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_rule}/ }).to_not be_nil
+
+            expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
           end
         end
@@ -2058,7 +2061,8 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
             expect(result.actions).to eq []
-            expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_rule}/ }).to_not be_nil
+
+            expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
           end
         end
@@ -2083,7 +2087,7 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
             expect(result.actions).to eq []
-            expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_rule}/ }).to_not be_nil
+            expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
           end
         end
@@ -2102,7 +2106,8 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
             expect(result.actions).to eq []
-            expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_rule}/ }).to_not be_nil
+
+            expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
           end
         end
@@ -2127,7 +2132,8 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
           expect(result.actions).to eq []
-          expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_rule}/ }).to_not be_nil
+
+          expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
         end
       end
@@ -2154,7 +2160,8 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
           expect(result.actions).to eq []
-          expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_rule}/ }).to_not be_nil
+
+          expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
         end
       end
@@ -2179,13 +2186,14 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
           expect(result.actions).to eq []
-          expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_rule}/ }).to_not be_nil
+
+          expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
         end
       end
     end
 
-    context 'running multiple times' do
+    context 'Evaluating multiple times' do
       let(:passing_input_user_agent) do
         passing_input
       end
@@ -2228,7 +2236,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.timeout).to eq false
         expect(result.actions).to eq []
 
-        expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_user_agent_rule}/ }).to_not be_nil
+        expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_user_agent_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
 
         code, result = context.run(passing_input_user_agent, timeout)
@@ -2240,7 +2248,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.timeout).to eq false
         expect(result.actions).to eq []
 
-        expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_user_agent_rule}/ }).to_not be_nil
+        expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_user_agent_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
       end
 
@@ -2284,7 +2292,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.actions).to eq []
 
           expect(result.events.find { |r| r['rule']['id'] == long_rule }).to_not be_nil
-          expect(log_store.find { |log| log[:message] =~ /Running .* #{long_rule}/ }).to_not be_nil
+          expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{long_rule}'/ }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
         end
 
@@ -2301,7 +2309,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.timeout).to eq false
 
           expect(result.events.find { |r| r['rule']['id'] == long_rule }).to_not be_nil
-          expect(log_store.find { |log| log[:message] =~ /Running .* #{long_rule}/ }).to_not be_nil
+          expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{long_rule}'/ }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
         end
       end
@@ -2368,7 +2376,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.timeout).to eq false
         expect(result.actions).to eq []
 
-        expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_user_agent_rule}/ }).to_not be_nil
+        expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_user_agent_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
 
         code, result = context.run(matching_input_user_agent, timeout)
@@ -2381,7 +2389,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.actions).to eq []
 
         expect(result.events.find { |r| r['rule']['id'] == matching_input_user_agent_rule }).to_not be_nil
-        expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_user_agent_rule}/ }).to_not be_nil
+        expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_user_agent_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
       end
 
@@ -2396,7 +2404,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.actions).to eq []
 
         expect(result.events.find { |r| r['rule']['id'] == matching_input_user_agent_rule }).to_not be_nil
-        expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_user_agent_rule}/ }).to_not be_nil
+        expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_user_agent_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
 
         code, result = context.run(matching_input_sqli, timeout)
@@ -2410,7 +2418,7 @@ RSpec.describe Datadog::AppSec::WAF do
 
         expect(result.events.find { |r| r['rule']['id'] == matching_input_user_agent_rule }).to be_nil
         expect(result.events.find { |r| r['rule']['id'] == matching_input_sqli_rule }).to_not be_nil
-        expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_sqli_rule}/ }).to_not be_nil
+        expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_sqli_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
       end
 
@@ -2424,7 +2432,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.timeout).to eq false
         expect(result.actions).to eq []
 
-        expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_path_rule}/ }).to_not be_nil
+        expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_path_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
 
         code, result = context.run(matching_input_status, timeout)
@@ -2437,7 +2445,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.actions).to eq []
 
         expect(result.events.find { |r| r['rule']['id'] == matching_input_path_rule }).to_not be_nil
-        expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_path_rule}/ }).to_not be_nil
+        expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_path_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
       end
 
@@ -2455,7 +2463,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.timeout).to eq false
           expect(result.actions).to eq []
 
-          expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_path_rule}/ }).to_not be_nil
+          expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_path_rule}'/ }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
         end.call
 
@@ -2474,7 +2482,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.actions).to eq []
 
           expect(result.events.find { |r| r['rule']['id'] == matching_input_path_rule }).to_not be_nil
-          expect(log_store.find { |log| log[:message] =~ /Running .* #{matching_input_path_rule}/ }).to_not be_nil
+          expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_path_rule}'/ }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
         end.call
       end

--- a/spec/datadog/appsec/waf_spec.rb
+++ b/spec/datadog/appsec/waf_spec.rb
@@ -2498,119 +2498,119 @@ RSpec.describe Datadog::AppSec::WAF do
         },
         'rules' => [
           {
-            "id": "crs-913-120",
-            "name": "Known security scanner filename/argument",
-            "tags": {
-              "type": "security_scanner",
-              "crs_id": "913120",
-              "category": "attack_attempt"
+            "id" => "crs-913-120",
+            "name" => "Known security scanner filename/argument",
+            "tags" => {
+              "type" => "security_scanner",
+              "crs_id" => "913120",
+              "category" => "attack_attempt"
             },
-            "conditions": [
+            "conditions" => [
               {
-                "parameters": {
-                  "inputs": [
+                "parameters" => {
+                  "inputs" => [
                     {
-                      "address": "server.request.query"
+                      "address" => "server.request.query"
                     },
                   ],
-                  "regex": "<EMBED[\\s/+].*?(?:src|type).*?=",
-                  "options": {
-                    "min_length": 11
+                  "regex" => "<EMBED[\\s/+].*?(?:src|type).*?=",
+                  "options" => {
+                    "min_length" => 11
                   }
                 },
-                "operator": "match_regex"
+                "operator" => "match_regex"
               }
             ],
-            "transformers": [
+            "transformers" => [
               "removeNulls"
             ]
           }
         ],
         # Extracted the processor configuration from
         # https://gist.github.com/Anilm3/db97e3f24869ee4f4d0eb96655df6983
-        "processors": [
+        "processors" => [
           {
-            "id": "processor-001",
-            "generator": "extract_schema",
-            "conditions": [
+            "id" => "processor-001",
+            "generator" => "extract_schema",
+            "conditions" => [
               {
-                "operator": "equals",
-                "parameters": {
-                  "inputs": [
+                "operator" => "equals",
+                "parameters" => {
+                  "inputs" => [
                     {
-                      "address": "waf.context.processor",
-                      "key_path": [
+                      "address" => "waf.context.processor",
+                      "key_path" => [
                         "extract-schema"
                       ]
                     }
                   ],
-                  "type": "boolean",
-                  "value": true
+                  "type" => "boolean",
+                  "value" => true
                 }
               }
             ],
-            "parameters": {
-              "mappings": [
+            "parameters" => {
+              "mappings" => [
                 {
-                  "inputs": [
+                  "inputs" => [
                     {
-                      "address": "server.request.body"
+                      "address" => "server.request.body"
                     }
                   ],
-                  "output": "_dd.appsec.s.req.body"
+                  "output" => "_dd.appsec.s.req.body"
                 },
                 {
-                  "inputs": [
+                  "inputs" => [
                     {
-                      "address": "server.request.headers.no_cookies"
+                      "address" => "server.request.headers.no_cookies"
                     }
                   ],
-                  "output": "_dd.appsec.s.req.headers"
+                  "output" => "_dd.appsec.s.req.headers"
                 },
                 {
-                  "inputs": [
+                  "inputs" => [
                     {
-                      "address": "server.request.query"
+                      "address" => "server.request.query"
                     }
                   ],
-                  "output": "_dd.appsec.s.req.query"
+                  "output" => "_dd.appsec.s.req.query"
                 },
                 {
-                  "inputs": [
+                  "inputs" => [
                     {
-                      "address": "server.request.path_params"
+                      "address" => "server.request.path_params"
                     }
                   ],
-                  "output": "_dd.appsec.s.req.params"
+                  "output" => "_dd.appsec.s.req.params"
                 },
                 {
-                  "inputs": [
+                  "inputs" => [
                     {
-                      "address": "server.request.cookies"
+                      "address" => "server.request.cookies"
                     }
                   ],
-                  "output": "_dd.appsec.s.req.cookies"
+                  "output" => "_dd.appsec.s.req.cookies"
                 },
                 {
-                  "inputs": [
+                  "inputs" => [
                     {
-                      "address": "server.response.headers.no_cookies"
+                      "address" => "server.response.headers.no_cookies"
                     }
                   ],
-                  "output": "_dd.appsec.s.res.headers"
+                  "output" => "_dd.appsec.s.res.headers"
                 },
                 {
-                  "inputs": [
+                  "inputs" => [
                     {
-                      "address": "server.response.body"
+                      "address" => "server.response.body"
                     }
                   ],
-                  "output": "_dd.appsec.s.res.body"
+                  "output" => "_dd.appsec.s.res.body"
                 }
               ]
             },
-            "evaluate": false,
-            "output": true
+            "evaluate" => false,
+            "output" => true
           }
         ]
       }


### PR DESCRIPTION
**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Update libddwaf to latest version `1.14.0` https://github.com/DataDog/libddwaf/releases/tag/1.14.0

**Motivation**
<!-- What inspired you to submit this pull request? -->

For the API secuirty work we are currently doing, we need the latest change from `1.14.0` version. The latest version allows us to extract the schema information from the waf addresses when provided with the correct configuration. 

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR.
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

