### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -94,14 +94,14 @@ jobs:
         if: ${{ matrix.cpu != 'amd64' }}
         run: |
           docker run --privileged --rm tonistiigi/binfmt:latest --install ${{ matrix.qemu }} | tee platforms.json
-          echo "::set-output name=platforms::$(cat platforms.json)"
+          echo "platforms=$(cat platforms.json)" >> "$GITHUB_OUTPUT"
       - name: Start container
         id: container
         run: |
           echo ${{ matrix.image }} > container_image
           docker run --rm -d -v "${PWD}":"${PWD}" -w "${PWD}" --platform linux/${{ matrix.qemu }} ${{ matrix.image }} /bin/sleep 64d | tee container_id
           docker exec -w "${PWD}" $(cat container_id) uname -a
-          echo "::set-output name=id::$(cat container_id)"
+          echo "id=$(cat container_id)" >> "$GITHUB_OUTPUT"
       - uses: actions/download-artifact@v2
         with:
           name: libddwaf-${{ matrix.platform }}-${{ github.run_id }}-${{ github.sha }}
@@ -163,14 +163,14 @@ jobs:
         if: ${{ matrix.cpu != 'amd64' }}
         run: |
           docker run --privileged --rm tonistiigi/binfmt:latest --install ${{ matrix.qemu }} | tee platforms.json
-          echo "::set-output name=platforms::$(cat platforms.json)"
+          echo "platforms=$(cat platforms.json)" >> "$GITHUB_OUTPUT"
       - name: Start container
         id: container
         run: |
           echo ${{ matrix.image }} > container_image
           docker run --rm -d -v "${PWD}":"${PWD}" -w "${PWD}" --platform linux/${{ matrix.qemu }} ${{ matrix.image }} /bin/sleep 64d | tee container_id
           docker exec -w "${PWD}" $(cat container_id) uname -a
-          echo "::set-output name=id::$(cat container_id)"
+          echo "id=$(cat container_id)" >> "$GITHUB_OUTPUT"
       - uses: actions/download-artifact@v2
         with:
           name: libddwaf-${{ matrix.artifact }}-${{ github.run_id }}-${{ github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,14 +161,14 @@ jobs:
         if: ${{ matrix.cpu != 'amd64' }}
         run: |
           docker run --privileged --rm tonistiigi/binfmt:latest --install ${{ matrix.qemu }} | tee platforms.json
-          echo "::set-output name=platforms::$(cat platforms.json)"
+          echo "platforms=$(cat platforms.json)" >> "$GITHUB_OUTPUT"
       - name: Start container
         id: container
         run: |
           echo ${{ matrix.image }} > container_image
           docker run --rm -d -v "${PWD}":"${PWD}" -w "${PWD}" --platform linux/${{ matrix.qemu }} ${{ matrix.image }} /bin/sleep 64d | tee container_id
           docker exec -w "${PWD}" $(cat container_id) uname -a
-          echo "::set-output name=id::$(cat container_id)"
+          echo "id=$(cat container_id)" >> "$GITHUB_OUTPUT"
       - name: Install Alpine system dependencies
         if: ${{ matrix.libc == 'musl' }}
         run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} apk add --no-cache build-base git


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter