### PR TITLE
Set minimum ffi gem version to 1.16

### DIFF
--- a/libddwaf.gemspec
+++ b/libddwaf.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
     end
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'ffi', '~> 1.0'
+  spec.add_dependency 'ffi', '~> 1.16'
 end


### PR DESCRIPTION
We found that older versions of `ffi` gem are leaking memory with Ruby >= 3.3.0.

This commit fixes the leak:
https://github.com/ffi/ffi/commit/ca2744aed44da7486b3839b879388af3f6307a88#diff-c9d4c2c832d295a8ae5f0fdfcef68a5420a30a1cfc0d3e346bb82afebe625a93

Since this commit is a part of `ffi` version 1.16, we want to lock the minimum version of `ffi` to 1.16.

**Motivation**
Memory leak that was reported by a customer, when enabling `appsec` in the Datadog gem configuration.

**Additional Notes**
-

**How to test the change?**
Please contact me, I will assist you in reproducing the leak locally.