### PR TITLE
Use local cache for docker/build-push-action in CI

### DIFF
--- a/.github/actions/docker-build-ruby/Dockerfile
+++ b/.github/actions/docker-build-ruby/Dockerfile
@@ -2,4 +2,6 @@ ARG RUBY_VERSION
 
 FROM ruby:${RUBY_VERSION:-2.5}
 
+RUN git config --global --add safe.directory '/libddwaf-rb'
+
 RUN gem update --system 3.3.27

--- a/.github/actions/docker-build-ruby/Dockerfile.alpine
+++ b/.github/actions/docker-build-ruby/Dockerfile.alpine
@@ -3,5 +3,6 @@ ARG RUBY_VERSION
 FROM ruby:${RUBY_VERSION:-2.5}-alpine
 
 RUN apk add --no-cache build-base git
+RUN git config --global --add safe.directory '/libddwaf-rb'
 
 RUN gem update --system 3.3.27

--- a/.github/actions/docker-build-ruby/Dockerfile.jruby
+++ b/.github/actions/docker-build-ruby/Dockerfile.jruby
@@ -4,3 +4,4 @@ FROM jruby:${RUBY_VERSION:-9.2}
 
 RUN apt-get update
 RUN apt-get install -y build-essential git
+RUN git config --global --add safe.directory '/libddwaf-rb'

--- a/.github/actions/docker-build-ruby/action.yml
+++ b/.github/actions/docker-build-ruby/action.yml
@@ -45,9 +45,17 @@ runs:
         push: false
         load: true
         tags: libddwaf-rb-test:latest
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
         platforms: linux/${{ inputs.arch }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+    
+    - # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: Set run-cmd output
       id: set-run-cmd

--- a/.github/actions/docker-build-ruby/action.yml
+++ b/.github/actions/docker-build-ruby/action.yml
@@ -53,6 +53,7 @@ runs:
       # https://github.com/docker/build-push-action/issues/252
       # https://github.com/moby/buildkit/issues/1896
       name: Move cache
+      shell: bash
       run: |
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/README.md
+++ b/README.md
@@ -84,11 +84,6 @@ Then you can substitute e.g `--platform linux/x86_64` with `--platform linux/aar
 
 ```
 # this is too old for aarch64
-docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.1 sh -c 'rm -fv Gemfile.lock && gem install bundler -v "~> 1.17" && bundle install && bundle exec rake spec'
-# these are fine for aarch64
-docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.2 sh -c 'rm -fv Gemfile.lock && gem install bundler -v "~> 1.17" && bundle install && bundle exec rake spec'
-docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.3 sh -c 'rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
-docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.4 sh -c 'rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
 docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.5 sh -c 'rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
 docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.6 sh -c 'rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
 docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.7 sh -c 'rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
@@ -100,12 +95,6 @@ docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" rub
 
 ```
 # these are too old for aarch64
-docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.1-alpine sh -c 'apk update && apk add build-base git && rm -fv Gemfile.lock && gem install bundler -v "~> 1.17" && bundle install && bundle exec rake spec'
-docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.2-alpine sh -c 'apk update && apk add build-base git && rm -fv Gemfile.lock && gem install bundler -v "~> 1.17" && bundle install && bundle exec rake spec'
-# these are fine for aarch64
-docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.3-alpine sh -c 'apk update && apk add build-base git && rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
-docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.4-alpine sh -c 'apk update && apk add build-base git && rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
-docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.5-alpine sh -c 'apk update && apk add build-base git && rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
 docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.6-alpine sh -c 'apk update && apk add build-base git && rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
 docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:2.7-alpine sh -c 'apk update && apk add build-base git && rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
 docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" ruby:3.0-alpine sh -c 'apk update && apk add build-base git && rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
@@ -117,7 +106,6 @@ docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" rub
 
 ```
 # these are too old for aarch64
-docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" jruby:9.2.8.0 sh -c 'apt-get update && apt-get install -y build-essential git && rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
 docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" jruby:9.3.0.0 sh -c 'apt-get update && apt-get install -y build-essential git && rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'
 # this is fine for aarch64
 docker run --rm -it --platform linux/x86_64 -v "${PWD}":"${PWD}" -w "${PWD}" jruby:9.3.4.0 sh -c 'apt-get update && apt-get install -y build-essential git && rm -fv Gemfile.lock && gem install bundler:2.2.22 && bundle install && bundle exec rake spec'


### PR DESCRIPTION
**What does this PR do?**
It switches `docker/build-push-action` cache from `gha` to `local`

**Motivation**
It seems that `gha` cache is not working properly - cache hits are at most 25%:
https://github.com/DataDog/libddwaf-rb/actions/runs/11477305787?pr=43

