### PR TITLE
[APPSEC-55057] Upgrade libddwaf 1.15

### DIFF
--- a/lib/datadog/appsec/waf.rb
+++ b/lib/datadog/appsec/waf.rb
@@ -227,7 +227,7 @@ module Datadog
         attach_function :ddwaf_update, [:ddwaf_handle, :ddwaf_object, :ddwaf_object], :ddwaf_handle
         attach_function :ddwaf_destroy, [:ddwaf_handle], :void
 
-        attach_function :ddwaf_required_addresses, [:ddwaf_handle, UInt32Ptr], :charptrptr
+        attach_function :ddwaf_known_addresses, [:ddwaf_handle, UInt32Ptr], :charptrptr
 
         # updating
 
@@ -536,7 +536,7 @@ module Datadog
           valid!
 
           count = Datadog::AppSec::WAF::LibDDWAF::UInt32Ptr.new
-          list = Datadog::AppSec::WAF::LibDDWAF.ddwaf_required_addresses(handle_obj, count)
+          list = Datadog::AppSec::WAF::LibDDWAF.ddwaf_known_addresses(handle_obj, count)
 
           return [] if count == 0 # list is null
 

--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -2,7 +2,7 @@ module Datadog
   module AppSec
     module WAF
       module VERSION
-        BASE_STRING = '1.14.0'
+        BASE_STRING = '1.15.0'
         STRING = "#{BASE_STRING}.0.0"
         MINIMUM_RUBY_VERSION = '2.1'
       end

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -112,7 +112,7 @@ module Datadog
         def self.ddwaf_update: (::FFI::Pointer, LibDDWAF::Object, LibDDWAF::Object) -> ::FFI::Pointer
         def self.ddwaf_destroy: (::FFI::Pointer) -> void
 
-        def self.ddwaf_required_addresses: (::FFI::Pointer, UInt32Ptr) -> ::FFI::Pointer
+        def self.ddwaf_known_addresses: (::FFI::Pointer, UInt32Ptr) -> ::FFI::Pointer
         def self.ddwaf_rule_data_ids: (::FFI::Pointer, UInt32Ptr) -> ::FFI::Pointer
 
         # updating

--- a/spec/datadog/appsec/waf_spec.rb
+++ b/spec/datadog/appsec/waf_spec.rb
@@ -1338,7 +1338,7 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
       expect(handle.null?).to be false
 
       count = Datadog::AppSec::WAF::LibDDWAF::UInt32Ptr.new
-      list = Datadog::AppSec::WAF::LibDDWAF.ddwaf_required_addresses(handle, count)
+      list = Datadog::AppSec::WAF::LibDDWAF.ddwaf_known_addresses(handle, count)
       expect(list.get_array_of_string(0, count[:value]).sort).to eq(['value1', 'value2'])
     end
 


### PR DESCRIPTION
**What does this PR do?**

This is an upgrade PR of `libddwaf` library to `1.15`

**Motivation**

Our end-goal is to keep up with libddwaf upgrades, latest so far `1.20.1`

**Additional Notes**

None

**How to test the change?**

```
appsec-app-generator $ bin/run -b libddwaf
appsec-app-generator $ curl 0:3000/block-me
```
