### PR TITLE
Set default value for `persistent_data` and `ephemeral_data`

### DIFF
--- a/lib/datadog/appsec/waf.rb
+++ b/lib/datadog/appsec/waf.rb
@@ -630,7 +630,7 @@ module Datadog
           valid!
 
           persistent_data_obj = Datadog::AppSec::WAF.ruby_to_object(
-            persistent_data,
+            persistent_data || {},
             max_container_size: LibDDWAF::DDWAF_MAX_CONTAINER_SIZE,
             max_container_depth: LibDDWAF::DDWAF_MAX_CONTAINER_DEPTH,
             max_string_length: LibDDWAF::DDWAF_MAX_STRING_LENGTH,
@@ -644,7 +644,7 @@ module Datadog
           retain(persistent_data_obj)
 
           ephemeral_data_obj = Datadog::AppSec::WAF.ruby_to_object(
-            ephemeral_data,
+            ephemeral_data || {},
             max_container_size: LibDDWAF::DDWAF_MAX_CONTAINER_SIZE,
             max_container_depth: LibDDWAF::DDWAF_MAX_CONTAINER_DEPTH,
             max_string_length: LibDDWAF::DDWAF_MAX_STRING_LENGTH,


### PR DESCRIPTION
We have to make sure that both `persistent_data` and `ephemeral_data` are not `nil`, since `libddwaf` returns `:ddwaf_err_invalid_object` error code when nil objects are provided as input data.

**Motivation**
Testing with `dd-trace-rb` reveals that we can not provide `nil` as input data to `Context#run`, for both ephemeral and persistent data.

**Additional Notes**
None

**How to test the change?**
```bash
bin/run -Vb libddwaf
curl http://localhost:3000/block-me
```

