### PR TITLE
Refactor rake fetch task with release download

### DIFF
--- a/.github/actions/docker-build-ruby/action.yml
+++ b/.github/actions/docker-build-ruby/action.yml
@@ -4,10 +4,6 @@ description:
   This action builds the image for the specified architecture and libc.
 
 inputs:
-  github-token:
-    description: Github API token
-    required: true
-
   ruby-version:
     description: Ruby version
     required: true
@@ -58,4 +54,4 @@ runs:
       id: set-run-cmd
       shell: bash
       run: |
-        echo "run-cmd=docker run -e "GITHUB_TOKEN=${{ inputs.github-token }}" --platform linux/${{ inputs.arch }} -v gems:/usr/local/bundle -v ${{ github.workspace }}:/libddwaf-rb -w /libddwaf-rb libddwaf-rb-test:latest" >> "$GITHUB_OUTPUT"
+        echo "run-cmd=docker run --platform linux/${{ inputs.arch }} -v gems:/usr/local/bundle -v ${{ github.workspace }}:/libddwaf-rb -w /libddwaf-rb libddwaf-rb-test:latest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -28,7 +28,6 @@ jobs:
         id: build-image
         uses: ./.github/actions/docker-build-ruby
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           ruby-version: ${{ matrix.ruby }}
           arch: ${{ matrix.arch }}
           libc: ${{ matrix.libc }}
@@ -81,7 +80,6 @@ jobs:
         id: build-image
         uses: ./.github/actions/docker-build-ruby
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           ruby-version: ${{ matrix.ruby }}
           arch: ${{ matrix.arch }}
           libc: ${{ matrix.libc }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
         id: build-image
         uses: ./.github/actions/docker-build-ruby
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           ruby-version: ${{ matrix.ruby }}
           arch: ${{ matrix.arch }}
           libc: ${{ matrix.libc }}
@@ -69,7 +68,6 @@ jobs:
         id: build-image
         uses: ./.github/actions/docker-build-ruby
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           ruby-version: ${{ matrix.jruby }}
           jruby: true
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
We changing back to generic release page url for `fetch` rake task. This PR slightly improves readability