### PR TITLE
Remove obsolete docker rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,58 +68,6 @@ namespace :coverage do
   end
 end
 
-# TODO: Migrate images to Datadog Docker repo
-RUBY_VERSIONS = {
-  '2.1' => { version: '2.1', image: 'delner/ruby:2.1', service: 'ruby-2.1' },
-  '2.2' => { version: '2.2', image: 'delner/ruby:2.2', service: 'ruby-2.2' },
-  '2.3' => { version: '2.3', image: 'delner/ruby:2.3', service: 'ruby-2.3' },
-  '2.4' => { version: '2.4', image: 'delner/ruby:2.4', service: 'ruby-2.4' },
-  '2.5' => { version: '2.5', image: 'delner/ruby:2.5', service: 'ruby-2.5' },
-  '2.6' => { version: '2.6', image: 'delner/ruby:2.6', service: 'ruby-2.6' },
-  '2.7' => { version: '2.7', image: 'delner/ruby:2.7', service: 'ruby-2.7' },
-  '3.0' => { version: '3.0', image: 'delner/ruby:3.0', service: 'ruby-3.0' },
-  'jruby-9.2' => { version: 'jruby-9.2', image: 'delner/ruby:jruby-9.2', service: 'jruby-9.2' }
-}.freeze
-
-DEFAULT_RUBY_VERSION = RUBY_VERSIONS['2.7']
-
-namespace :docker do
-  task :build do
-    RUBY_VERSIONS.each_value do |ruby|
-      command = 'docker build'
-      command += " -t #{ruby[:image]}"
-      command += ' -t delner/ruby:latest' if ruby == DEFAULT_RUBY_VERSION
-      command += " -f .docker/images/ruby/#{ruby[:version]}/Dockerfile"
-      command += " .docker/images/ruby/#{ruby[:version]}"
-
-      system!(command)
-    end
-  end
-
-  task :push do
-    RUBY_VERSIONS.each_value do |ruby|
-      command = 'docker push'
-      command += " #{ruby[:image]}"
-
-      system!(command)
-      system!('docker push delner/ruby:latest') if ruby == DEFAULT_RUBY_VERSION
-    end
-  end
-
-  task :run do
-    # Select Docker service to run
-    ruby_version = RUBY_VERSIONS.find do |ver, ruby|
-      ver == ENV['RUBY_VER'] \
-        || ruby[:version] == ENV['RUBY_VER'] \
-        || ruby[:service] == ENV['RUBY_VER']
-    end || DEFAULT_RUBY_VERSION
-
-    # Build and start Docker container
-    system! "docker-compose build #{ruby_version[:service]}"
-    system! "docker-compose run --rm #{ruby_version[:service]}"
-  end
-end
-
 module Helpers
   require 'uri'
   require 'json'


### PR DESCRIPTION
This PR removes `docker` rake tasks, since they are obsolete.

**Motivation**
It seems that `.docker` folder that contained dockerfiles was deleted some time ago, and these tasks are broken.

**Additional Notes**
Nope

**How to test the change?**
```
bundle exec rake --tasks
```
