### PR TITLE
Update libddwaf to 1.16.1, fix `libddwaf:fetch` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -88,11 +88,11 @@ module Helpers
   end
 
   def libddwaf_tarball_filename(platform:)
-    platform += if Gem::Version.new(libddwaf_version) >= Gem::Version.new('1.16.0') && platform.os == 'linux'
-                  [platform.cpu, platform.os, 'musl'].compact.join('-')
-                else
-                  [platform.os, platform.version, platform.cpu].compact.join('-')
-                end
+    platform = if Gem::Version.new(libddwaf_version) >= Gem::Version.new('1.16.0') && platform.os == 'linux'
+                 [platform.cpu, platform.os, 'musl'].compact.join('-')
+               else
+                 [platform.os, platform.version, platform.cpu].compact.join('-')
+               end
 
     "libddwaf-#{libddwaf_version}-#{platform}.tar.gz"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -88,15 +88,13 @@ module Helpers
   end
 
   def libddwaf_tarball_filename(platform:)
-    filename = "libddwaf-#{libddwaf_version}-"
-
-    filename += if Gem::Version.new(libddwaf_version) >= Gem::Version.new('1.16.0') && platform.os == 'linux'
+    platform += if Gem::Version.new(libddwaf_version) >= Gem::Version.new('1.16.0') && platform.os == 'linux'
                   [platform.cpu, platform.os, 'musl'].compact.join('-')
                 else
                   [platform.os, platform.version, platform.cpu].compact.join('-')
                 end
 
-    filename + '.tar.gz'
+    "libddwaf-#{libddwaf_version}-#{platform}.tar.gz"
   end
 
   def libddwaf_binary_checksum(binary_name)

--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -2,7 +2,7 @@ module Datadog
   module AppSec
     module WAF
       module VERSION
-        BASE_STRING = '1.15.0'
+        BASE_STRING = '1.16.1'
         STRING = "#{BASE_STRING}.0.0"
         MINIMUM_RUBY_VERSION = '2.5'
       end


### PR DESCRIPTION
Unfortunately, the archive filename has changed for `libddwaf` releases from version `1.16.0`.

Now the release file name consists of CPU architecture, OS and `-musl` prefix. Again unfortunately, this change is only for linux releases.

Another catch is that the extracted folder name is still in the old format.

**What does this PR do?**
This PR changes the expected archive filename for versions of `libddwaf` newer than `1.16.0`.

**Motivation**
None

**Additional Notes**
None

**How to test the change?**
```bash
bundle exec rake libddwaf:fetch
```