### PR TITLE
[APPSEC-55683] Upgrade libddwaf to 1.18

### DIFF
--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -2,7 +2,7 @@ module Datadog
   module AppSec
     module WAF
       module VERSION
-        BASE_STRING = '1.16.1'
+        BASE_STRING = '1.18.0'
         STRING = "#{BASE_STRING}.0.0"
         MINIMUM_RUBY_VERSION = '2.5'
       end

--- a/spec/datadog/appsec/waf/lib_ddwaf_spec.rb
+++ b/spec/datadog/appsec/waf/lib_ddwaf_spec.rb
@@ -601,6 +601,28 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
             ],
             'on_match' => ['action1', 'action2', 'action3', 'action4']
           }
+        ],
+        'actions' => [
+          {
+            'id' => 'action1',
+            'type' => 'block',
+            'parameters' => { 'status_code' => '401', 'grpc_status_code' => '41', 'type' => 'auto' }
+          },
+          {
+            'id' => 'action2',
+            'type' => 'extract_schema',
+            'parameters' => { 'status_code' => '402', 'grpc_status_code' => '42', 'type' => 'auto' }
+          },
+          {
+            'id' => 'action3',
+            'type' => 'stacktrace',
+            'parameters' => { 'status_code' => '403', 'grpc_status_code' => '43', 'type' => 'auto' }
+          },
+          {
+            'id' => 'action4',
+            'type' => 'unblock',
+            'parameters' => { 'status_code' => '404', 'grpc_status_code' => '44', 'type' => 'auto' }
+          }
         ]
       }
     end
@@ -844,7 +866,8 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
       expect(result[:actions]).to be_a described_class::Object
       expect(described_class.ddwaf_object_size(result[:actions])).to eq 4
       # TODO: not sure why libddwaf reverses actions
-      expect(Datadog::AppSec::WAF::Converter.object_to_ruby(result[:actions])).to eq ['action1', 'action2', 'action3', 'action4'].reverse
+      actions = Datadog::AppSec::WAF::Converter.object_to_ruby(result[:actions]).keys
+      expect(actions).to eq ['block', 'extract_schema', 'stacktrace', 'unblock'].reverse
     end
   end
 end

--- a/spec/datadog/appsec/waf_spec.rb
+++ b/spec/datadog/appsec/waf_spec.rb
@@ -120,12 +120,12 @@ RSpec.describe Datadog::AppSec::WAF do
     it 'passes non-matching persistent data' do
       code, result = context.run(passing_input, {}, timeout_usec)
       perf_store[:total_runtime] << result.total_runtime
-      expect(code).to eq :ok
-      expect(result.status).to eq :ok
-      expect(result.events).to eq []
+      expect(code).to eq(:ok)
+      expect(result.status).to eq(:ok)
+      expect(result.events).to eq([])
       expect(result.total_runtime).to be > 0
-      expect(result.timeout).to eq false
-      expect(result.actions).to eq []
+      expect(result.timeout).to eq(false)
+      expect(result.actions).to eq({})
     end
 
     it 'passes non-matching ephemeral data' do
@@ -135,8 +135,8 @@ RSpec.describe Datadog::AppSec::WAF do
       expect(result.status).to eq :ok
       expect(result.events).to eq []
       expect(result.total_runtime).to be > 0
-      expect(result.timeout).to eq false
-      expect(result.actions).to eq []
+      expect(result.timeout).to eq(false)
+      expect(result.actions).to eq({})
     end
 
     it 'catches a match on persistent data' do
@@ -147,7 +147,7 @@ RSpec.describe Datadog::AppSec::WAF do
       expect(result.events).to be_a Array
       expect(result.total_runtime).to be > 0
       expect(result.timeout).to eq false
-      expect(result.actions).to eq []
+      expect(result.actions).to eq({})
     end
 
     it 'catches a match on ephemeral data' do
@@ -158,7 +158,7 @@ RSpec.describe Datadog::AppSec::WAF do
       expect(result.events).to be_a Array
       expect(result.total_runtime).to be > 0
       expect(result.timeout).to eq false
-      expect(result.actions).to eq []
+      expect(result.actions).to eq({})
     end
 
     context 'encoding' do
@@ -175,7 +175,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.events).to be_a Array
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
-          expect(result.actions).to eq []
+          expect(result.actions).to eq({})
         end
       end
 
@@ -198,7 +198,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.events).to be_a Array
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
-          expect(result.actions).to eq []
+          expect(result.actions).to eq({})
         end
       end
     end
@@ -388,7 +388,7 @@ RSpec.describe Datadog::AppSec::WAF do
           new_context = described_class::Context.new(new_handle)
           code, result = new_context.run(matching_input, {}, timeout_usec)
           expect(code).to eq :match
-          expect(result.actions).to eq(['block'])
+          expect(result.actions.keys).to eq(['block_request'])
 
           new_context.finalize
           new_handle.finalize
@@ -559,7 +559,7 @@ RSpec.describe Datadog::AppSec::WAF do
       expect(result.events).to eq []
       expect(result.total_runtime).to be > 0
       expect(result.timeout).to eq false
-      expect(result.actions).to eq []
+      expect(result.actions).to eq({})
       expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
       expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
     end
@@ -572,7 +572,7 @@ RSpec.describe Datadog::AppSec::WAF do
       expect(result.events).to be_a Array
       expect(result.total_runtime).to be > 0
       expect(result.timeout).to eq false
-      expect(result.actions).to eq []
+      expect(result.actions).to eq({})
       expect(result.events.find { |r| r['rule']['id'] == matching_input_rule }).to_not be_nil
       expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
       expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -597,7 +597,7 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.events).to be_a Array
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
-            expect(result.actions).to eq []
+            expect(result.actions).to eq({})
 
             expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -617,7 +617,7 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.events).to be_a Array
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
-            expect(result.actions).to eq []
+            expect(result.actions).to eq({})
 
             expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -637,7 +637,7 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.events).to eq []
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
-            expect(result.actions).to eq []
+            expect(result.actions).to eq({})
 
             expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -657,7 +657,7 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.events).to eq []
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
-            expect(result.actions).to eq []
+            expect(result.actions).to eq({})
 
             expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -683,7 +683,7 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.events).to eq []
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
-            expect(result.actions).to eq []
+            expect(result.actions).to eq({})
             expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
           end
@@ -702,7 +702,7 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.events).to be_a Array
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
-            expect(result.actions).to eq []
+            expect(result.actions).to eq({})
 
             expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
             expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -728,7 +728,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.events).to eq []
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
-          expect(result.actions).to eq []
+          expect(result.actions).to eq({})
 
           expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -756,7 +756,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.events.first['rule_matches'].first['parameters'].first['highlight']).to include '<Redacted>'
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
-          expect(result.actions).to eq []
+          expect(result.actions).to eq({})
 
           expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -782,7 +782,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.events.first['rule_matches'].first['parameters'].first['highlight']).to include '<Redacted>'
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
-          expect(result.actions).to eq []
+          expect(result.actions).to eq({})
 
           expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_rule}'/ }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -831,7 +831,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.events).to eq []
         expect(result.total_runtime).to be > 0
         expect(result.timeout).to eq false
-        expect(result.actions).to eq []
+        expect(result.actions).to eq({})
 
         expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_user_agent_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -843,7 +843,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.events).to eq []
         expect(result.total_runtime).to be > 0
         expect(result.timeout).to eq false
-        expect(result.actions).to eq []
+        expect(result.actions).to eq({})
 
         expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_user_agent_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -857,7 +857,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.events).to be_a Array
         expect(result.total_runtime).to be > 0
         expect(result.timeout).to eq false
-        expect(result.actions).to eq []
+        expect(result.actions).to eq({})
 
         code, result = context.run(matching_input_user_agent, {}, timeout_usec)
         perf_store[:total_runtime] << result.total_runtime
@@ -866,7 +866,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.events).to eq []
         expect(result.total_runtime).to be > 0
         expect(result.timeout).to eq false
-        expect(result.actions).to eq []
+        expect(result.actions).to eq({})
 
         # TODO: also stress test changing matching values, e.g using arachni/v\d+
         # CHECK: maybe it will bail out and return only the first one?
@@ -886,7 +886,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.events).to be_a Array
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
-          expect(result.actions).to eq []
+          expect(result.actions).to eq({})
 
           expect(result.events.find { |r| r['rule']['id'] == long_rule }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{long_rule}'/ }).to_not be_nil
@@ -923,7 +923,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.events).to be_a Array
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
-          expect(result.actions).to eq []
+          expect(result.actions).to eq({})
 
           # stress test rerun on unchanged input
           100.times do
@@ -935,7 +935,7 @@ RSpec.describe Datadog::AppSec::WAF do
             expect(result.events).to eq []
             expect(result.total_runtime).to be > 0
             expect(result.timeout).to eq false
-            expect(result.actions).to eq []
+            expect(result.actions).to eq({})
           end
 
           # TODO: also stress test changing matching values, e.g using arachni/v\d+
@@ -957,7 +957,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to_not be_nil
 
           expect(result.timeout).to eq true
-          expect(result.actions).to eq []
+          expect(result.actions).to eq({})
         end
       end
 
@@ -969,7 +969,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.events).to eq []
         expect(result.total_runtime).to be > 0
         expect(result.timeout).to eq false
-        expect(result.actions).to eq []
+        expect(result.actions).to eq({})
 
         expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_user_agent_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -981,7 +981,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.events).to be_a Array
         expect(result.total_runtime).to be > 0
         expect(result.timeout).to eq false
-        expect(result.actions).to eq []
+        expect(result.actions).to eq({})
 
         expect(result.events.find { |r| r['rule']['id'] == matching_input_user_agent_rule }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_user_agent_rule}'/ }).to_not be_nil
@@ -996,7 +996,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.events).to be_a Array
         expect(result.total_runtime).to be > 0
         expect(result.timeout).to eq false
-        expect(result.actions).to eq []
+        expect(result.actions).to eq({})
 
         expect(result.events.find { |r| r['rule']['id'] == matching_input_user_agent_rule }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_user_agent_rule}'/ }).to_not be_nil
@@ -1009,7 +1009,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.events).to be_a Array
         expect(result.total_runtime).to be > 0
         expect(result.timeout).to eq false
-        expect(result.actions).to eq []
+        expect(result.actions).to eq({})
 
         expect(result.events.find { |r| r['rule']['id'] == matching_input_user_agent_rule }).to be_nil
         expect(result.events.find { |r| r['rule']['id'] == matching_input_sqli_rule }).to_not be_nil
@@ -1025,7 +1025,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.events).to eq []
         expect(result.total_runtime).to be > 0
         expect(result.timeout).to eq false
-        expect(result.actions).to eq []
+        expect(result.actions).to eq({})
 
         expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_path_rule}'/ }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -1037,7 +1037,7 @@ RSpec.describe Datadog::AppSec::WAF do
         expect(result.events).to be_a Array
         expect(result.total_runtime).to be > 0
         expect(result.timeout).to eq false
-        expect(result.actions).to eq []
+        expect(result.actions).to eq({})
 
         expect(result.events.find { |r| r['rule']['id'] == matching_input_path_rule }).to_not be_nil
         expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_path_rule}'/ }).to_not be_nil
@@ -1056,7 +1056,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.events).to eq []
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
-          expect(result.actions).to eq []
+          expect(result.actions).to eq({})
 
           expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_path_rule}'/ }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Ran out of time/ }).to be_nil
@@ -1074,7 +1074,7 @@ RSpec.describe Datadog::AppSec::WAF do
           expect(result.events).to be_a Array
           expect(result.total_runtime).to be > 0
           expect(result.timeout).to eq false
-          expect(result.actions).to eq []
+          expect(result.actions).to eq({})
 
           expect(result.events.find { |r| r['rule']['id'] == matching_input_path_rule }).to_not be_nil
           expect(log_store.find { |log| log[:message] =~ /Evaluating .* '#{matching_input_path_rule}'/ }).to_not be_nil


### PR DESCRIPTION
**What does this PR do?**

Upgrading `libddwaf` to 1.18.0

**Motivation**

In 1.18.0 SQLi detector was introduced

**Additional Notes**

There is a change in interface of actions, but it didn't break libddwaf-rb itself

**How to test the change?**

```
appsec-app-generator $ bin/run -b raw-sqli
```
