### PR TITLE
Add support for JRuby on macOS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -87,6 +87,22 @@ module Helpers
       platform.instance_eval { @version = $1 }
     end
 
+    if platform.os == 'java'
+      os_name = java.lang.System.get_property('os.name')
+      os_arch = java.lang.System.get_property('os.arch')
+      os = case os_name
+           when /linux/i then 'linux'
+           when /mac/i   then 'darwin'
+           else raise Error, "unsupported JRuby os.name: #{os_name.inspect}"
+           end
+      cpu = case os_arch
+            when 'amd64' then 'x86_64'
+            when 'aarch64' then os == 'darwin' ? 'arm64' : 'aarch64'
+            else raise Error, "unsupported JRuby os.arch: #{os_arch.inspect}"
+            end
+      return Gem::Platform.new("#{cpu}-#{os}")
+    end
+
     platform
   end
 

--- a/lib/datadog/appsec/waf/lib_ddwaf.rb
+++ b/lib/datadog/appsec/waf/lib_ddwaf.rb
@@ -95,7 +95,9 @@ module Datadog
         end
 
         def self.shared_lib_extname
-          if Gem::Platform.local.os == 'darwin' || Gem::Platform.local.os == 'java' && java.lang.System.get_property('os.name').match(/mac/i)
+          if Gem::Platform.local.os == 'darwin'
+            '.dylib'
+          elsif Gem::Platform.local.os == 'java' && java.lang.System.get_property('os.name').match(/mac/i)
             '.dylib'
           else
             '.so'

--- a/lib/datadog/appsec/waf/lib_ddwaf.rb
+++ b/lib/datadog/appsec/waf/lib_ddwaf.rb
@@ -53,7 +53,7 @@ module Datadog
 
             cpu = case os_arch
                   when 'amd64' then 'x86_64'
-                  when 'aarch64' then 'aarch64'
+                  when 'aarch64' then local_os == 'darwin' ? 'arm64' : 'aarch64'
                   else raise Error, "unsupported JRuby os.arch: #{os_arch.inspect}"
                   end
 
@@ -95,7 +95,11 @@ module Datadog
         end
 
         def self.shared_lib_extname
-          Gem::Platform.local.os == 'darwin' ? '.dylib' : '.so'
+          if Gem::Platform.local.os == 'darwin' || Gem::Platform.local.os == 'java' && java.lang.System.get_property('os.name').match(/mac/i)
+            '.dylib'
+          else
+            '.so'
+          end
         end
 
         def self.shared_lib_path


### PR DESCRIPTION
**What does this PR do?**
This PR fixes installation and execution of libddwaf-rb on JRuby on MacOS

**Motivation**
I wanted to test our RSpec testsuite using JRuby on MacOS but could not download nor use libddwaf library

**Additional notes**
I did not added a Github Action task for this, as the only use case for this is dockerless dev env

**How to test the change?**
Install JRuby with rbenv, and run `bundle install`, `bundle exec rake extract` and `bundle exec rake spec`

