### PR TITLE
Update libddwaf to 1.19.1

### DIFF
--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -2,7 +2,7 @@ module Datadog
   module AppSec
     module WAF
       module VERSION
-        BASE_STRING = '1.18.0'
+        BASE_STRING = '1.19.1'
         STRING = "#{BASE_STRING}.0.1"
         MINIMUM_RUBY_VERSION = '2.5'
       end

--- a/spec/datadog/appsec/waf/handle_spec.rb
+++ b/spec/datadog/appsec/waf/handle_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe Datadog::AppSec::WAF::Handle do
             }
           ],
           'action' => 'record'
+        },
+        {
+          'id' => 2,
+          'name' => 'Rule 2',
+          'tags' => { 'type' => 'flow2' },
+          'conditions' => [
+            {
+              'operator' => 'match_regex',
+              'parameters' => { 'inputs' => [{ 'address' => 'value2' }], 'regex' => 'rule2' }
+            }
+          ],
+          'action' => 'record'
         }
       ]
     }
@@ -84,7 +96,7 @@ RSpec.describe Datadog::AppSec::WAF::Handle do
 
   it 'records good diagnostics' do
     expect(handle.diagnostics).to be_a Hash
-    expect(handle.diagnostics['rules']['loaded'].size).to eq(1)
+    expect(handle.diagnostics['rules']['loaded'].size).to eq(2)
     expect(handle.diagnostics['rules']['failed'].size).to eq(0)
     expect(handle.diagnostics['rules']['errors']).to be_empty
     expect(handle.diagnostics['ruleset_version']).to eq('1.2.3')


### PR DESCRIPTION
**What does this PR do?**
This PR updates libddwaf to 1.19.1

**Motivation**
We need to update `libddwaf` to a more recent version.

**Additional Notes**
WAF Handle cannot be created without rules after [PR#314](https://github.com/DataDog/libddwaf/pull/314/files#diff-d067197e9befed2abc2cac3d47e95a647139db7939bd1a1334a1b51a4c257864R198-R201), this is why we are changing tests.

**How to test the change?**
CI

