### PR TITLE
Update libddwaf version to 1.21.0

### DIFF
--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -2,7 +2,7 @@ module Datadog
   module AppSec
     module WAF
       module VERSION
-        BASE_STRING = '1.20.1'
+        BASE_STRING = '1.21.0'
         STRING = "#{BASE_STRING}.0.1"
         MINIMUM_RUBY_VERSION = '2.5'
       end


### PR DESCRIPTION
**What does this PR do?**
It updates libddwaf to 1.21.0.

**Motivation**
This is the last easy update before 1.22.0.

**Additional Notes**
None.

**How to test the change?**
CI and app generator.

