### PR TITLE
Update libddwaf to 1.24.1

### DIFF
--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -2,7 +2,7 @@ module Datadog
   module AppSec
     module WAF
       module VERSION
-        BASE_STRING = "1.23.0"
+        BASE_STRING = "1.24.1"
         # NOTE: Every change to the `BASE_STRING` should be accompanied
         #       by a reset of the patch version in the `STRING` below.
         STRING = "#{BASE_STRING}.0.0"


### PR DESCRIPTION
**What does this PR do?**
It updates `libddwaf` to 1.24.1

**Motivation**
This should be a quick update without any breaking changes.

**Additional Notes**
None.

**How to test the change?**
CI and manual testing.