### PR TITLE
Remove obsolete TODO comment

### DIFF
--- a/lib/datadog/appsec/waf/handle.rb
+++ b/lib/datadog/appsec/waf/handle.rb
@@ -45,7 +45,6 @@ module Datadog
           return [] if count == 0 # list is null
 
           list.get_array_of_string(0, count[:value])
-          # TODO: garbage collect the count?
         end
 
         private


### PR DESCRIPTION
**What does this PR do?**
It removes one unnecessary comment - we have a memory leak test to ensure that this method is not leaking memory.

**Motivation**
I have found this comment in the code.

**Additional Notes**
None.

**How to test the change?**
-

