### PR TITLE
Add gnu and musl back to the platforms list

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -318,9 +318,9 @@ namespace :libddwaf do
     subplatform_for = {
       # lean gems
       "x86_64-linux-gnu" => ["x86_64-linux"],
-      "x86_64-linux-musl" => ["x86_64-linux-musl"],
+      "x86_64-linux-musl" => ["x86_64-linux"],
       "aarch64-linux-gnu" => ["aarch64-linux"],
-      "aarch64-linux-musl" => ["aarch64-linux-musl"],
+      "aarch64-linux-musl" => ["aarch64-linux"],
       "x86_64-darwin" => ["x86_64-darwin"],
       "arm64-darwin" => ["arm64-darwin"],
 
@@ -458,9 +458,13 @@ desc "Release gem for variaty of platforms"
 task release_multi: :release do
   platforms = %w[
     x86_64-linux
+    x86_64-linux-gnu
+    x86_64-linux-musl
     x86_64-darwin
     arm64-darwin
     aarch64-linux
+    aarch64-linux-gnu
+    aarch64-linux-musl
     java
   ]
 


### PR DESCRIPTION
**What does this PR do?**

Add GNU and MUSL `glibc` variants to the list of published platforms

**Motivation**

We have notice that we need to publish additionally  `-gnu` and `-musl` platforms in order to prevent certain installation issues. Now on multi-release those 4 new combinations will be published.

**Additional Notes**

None.

**How to test the change?**

CI.