### PR TITLE
Bump version to 1.24.1.0.3

### DIFF
--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -5,7 +5,7 @@ module Datadog
         BASE_STRING = "1.24.1"
         # NOTE: Every change to the `BASE_STRING` should be accompanied
         #       by a reset of the patch version in the `STRING` below.
-        STRING = "#{BASE_STRING}.0.2"
+        STRING = "#{BASE_STRING}.0.3"
         MINIMUM_RUBY_VERSION = "2.5"
       end
     end


### PR DESCRIPTION
**What does this PR do?**

New release with trimmed platform-specific gems

**How to test the change?**

CI