### PR TITLE
Add LibDDWAF::Object#input_truncated?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# Unreleased v1.23.0.0.0
+# Unreleased
+
+## Added
+
+- Add `LibDDWAF::Object#input_truncated?` method that returns true if the input object was truncated during conversion to libddwaf object
+
+# 2025-05-20 v1.24.1.0.0
 
 ## Added
 

--- a/lib/datadog/appsec/waf/converter.rb
+++ b/lib/datadog/appsec/waf/converter.rb
@@ -8,7 +8,7 @@ module Datadog
         module_function
 
         # standard:disable Metrics/MethodLength,Metrics/CyclomaticComplexity
-        def ruby_to_object(val, max_container_size: nil, max_container_depth: nil, max_string_length: nil, coerce: true)
+        def ruby_to_object(val, max_container_size: nil, max_container_depth: nil, max_string_length: nil, top_obj: nil, coerce: true)
           case val
           when Array
             obj = LibDDWAF::Object.new
@@ -16,19 +16,26 @@ module Datadog
             raise ConversionError, "Could not convert into object: #{val}" if res.null?
 
             max_index = max_container_size - 1 if max_container_size
-            unless max_container_depth == 0
+            # TODO: we must pass top object to be able to mark is as truncated
+            if max_container_depth == 0
+              top_obj&.mark_as_input_truncated!
+            else
               val.each.with_index do |e, i|
                 member = Converter.ruby_to_object(
                   e,
                   max_container_size: max_container_size,
                   max_container_depth: (max_container_depth - 1 if max_container_depth),
                   max_string_length: max_string_length,
+                  top_obj: top_obj || obj,
                   coerce: coerce
                 )
                 e_res = LibDDWAF.ddwaf_object_array_add(obj, member)
                 raise ConversionError, "Could not add to array object: #{e.inspect}" unless e_res
 
-                break val if max_index && i >= max_index
+                if max_index && i >= max_index
+                  obj.mark_as_input_truncated!
+                  break val
+                end
               end
             end
 
@@ -39,24 +46,33 @@ module Datadog
             raise ConversionError, "Could not convert into object: #{val}" if res.null?
 
             max_index = max_container_size - 1 if max_container_size
-            unless max_container_depth == 0
+            if max_container_depth == 0
+              top_obj&.mark_as_input_truncated!
+            else
               val.each.with_index do |e, i|
                 # for Steep, which doesn't handle |(k, v), i|
                 k = e[0]
                 v = e[1]
 
-                k = k.to_s[0, max_string_length] if max_string_length
+                if max_string_length && k.length > max_string_length
+                  k = k.to_s[0, max_string_length]
+                  obj.mark_as_input_truncated!
+                end
                 member = Converter.ruby_to_object(
                   v,
                   max_container_size: max_container_size,
                   max_container_depth: (max_container_depth - 1 if max_container_depth),
                   max_string_length: max_string_length,
+                  top_obj: top_obj || obj,
                   coerce: coerce
                 )
                 kv_res = LibDDWAF.ddwaf_object_map_addl(obj, k.to_s, k.to_s.bytesize, member)
                 raise ConversionError, "Could not add to map object: #{k.inspect} => #{v.inspect}" unless kv_res
 
-                break val if max_index && i >= max_index
+                if max_index && i >= max_index
+                  obj.mark_as_input_truncated!
+                  break val
+                end
               end
             end
 
@@ -64,15 +80,21 @@ module Datadog
           when String
             obj = LibDDWAF::Object.new
             encoded_val = val.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
-            val = encoded_val[0, max_string_length] if max_string_length
-            str = val.to_s
+            if max_string_length && encoded_val.length > max_string_length
+              encoded_val = encoded_val[0, max_string_length]
+              obj.mark_as_input_truncated!
+            end
+            str = encoded_val.to_s
             res = LibDDWAF.ddwaf_object_stringl(obj, str, str.bytesize)
             raise ConversionError, "Could not convert into object: #{val.inspect}" if res.null?
 
             obj
           when Symbol
             obj = LibDDWAF::Object.new
-            val = val.to_s[0, max_string_length] if max_string_length
+            if max_string_length
+              val = val.to_s[0, max_string_length]
+              obj.mark_as_input_truncated!
+            end
             str = val.to_s
             res = LibDDWAF.ddwaf_object_stringl(obj, str, str.bytesize)
             raise ConversionError, "Could not convert into object: #{val.inspect}" if res.null?

--- a/lib/datadog/appsec/waf/lib_ddwaf.rb
+++ b/lib/datadog/appsec/waf/lib_ddwaf.rb
@@ -136,6 +136,14 @@ module Datadog
             :valueUnion, ObjectValueUnion,
             :nbEntries, :uint64,
             :type, :ddwaf_obj_type
+
+          def input_truncated?
+            @input_truncated == true
+          end
+
+          def mark_as_input_truncated!
+            @input_truncated = true
+          end
         end
 
         typedef Object.by_ref, :ddwaf_object

--- a/sig/datadog/appsec/waf/converter.rbs
+++ b/sig/datadog/appsec/waf/converter.rbs
@@ -2,7 +2,7 @@ module Datadog
   module AppSec
     module WAF
       module Converter
-        def self.ruby_to_object: (top val, ?max_container_size: ::Integer?, ?max_container_depth: ::Integer?, ?max_string_length: ::Integer?, ?coerce: bool?) -> LibDDWAF::Object
+        def self.ruby_to_object: (top val, ?max_container_size: ::Integer?, ?max_container_depth: ::Integer?, ?max_string_length: ::Integer?, ?top_obj: LibDDWAF::Object?, ?coerce: bool?) -> LibDDWAF::Object
 
         def self.object_to_ruby: (LibDDWAF::Object obj) -> WAF::data
       end

--- a/sig/datadog/appsec/waf/lib_ddwaf.rbs
+++ b/sig/datadog/appsec/waf/lib_ddwaf.rbs
@@ -58,6 +58,9 @@ module Datadog
         end
 
         class Object < ::FFI::Struct[::FFI::AbstractMemory, untyped]
+          def input_truncated?: () -> bool
+
+          def mark_as_input_truncated!: () -> bool
         end
 
         # setters

--- a/spec/datadog/appsec/waf/converter_spec.rb
+++ b/spec/datadog/appsec/waf/converter_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 0
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq ""
+        expect(obj.input_truncated?).to eq(false)
       end
 
       it "converts an unhandled object" do
@@ -19,6 +20,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 0
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq ""
+        expect(obj.input_truncated?).to eq(false)
       end
 
       it "converts a boolean" do
@@ -30,6 +32,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 5
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "false"
+        expect(obj.input_truncated?).to eq(false)
       end
 
       it "converts a string" do
@@ -37,6 +40,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 3
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "foo"
+        expect(obj.input_truncated?).to eq(false)
       end
 
       it "converts a binary string" do
@@ -44,6 +48,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 7
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "foo\x00bar"
+        expect(obj.input_truncated?).to eq(false)
       end
 
       it "converts a symbol" do
@@ -51,6 +56,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 3
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "foo"
+        expect(obj.input_truncated?).to eq(false)
       end
 
       it "converts a positive integer" do
@@ -58,6 +64,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 2
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "42"
+        expect(obj.input_truncated?).to eq(false)
       end
 
       it "converts a negative integer" do
@@ -65,6 +72,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 3
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "-42"
+        expect(obj.input_truncated?).to eq(false)
       end
 
       it "converts a float" do
@@ -72,6 +80,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 17
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "3.141592653589793"
+        expect(obj.input_truncated?).to eq(false)
       end
 
       it "converts an empty array" do
@@ -79,12 +88,14 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_array
         expect(obj[:nbEntries]).to eq 0
         expect(obj[:valueUnion][:array].null?).to be true
+        expect(obj.input_truncated?).to eq(false)
       end
 
       it "converts a non-empty array" do
         obj = described_class.ruby_to_object((1..6).to_a)
         expect(obj[:type]).to eq :ddwaf_obj_array
         expect(obj[:nbEntries]).to eq 6
+        expect(obj.input_truncated?).to eq(false)
         array = (0...obj[:nbEntries]).each.with_object([]) do |i, a|
           ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
           o = Datadog::AppSec::WAF::LibDDWAF::Object.new(ptr)
@@ -100,12 +111,14 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_map
         expect(obj[:nbEntries]).to eq 0
         expect(obj[:valueUnion][:array].null?).to be true
+        expect(obj.input_truncated?).to eq(false)
       end
 
       it "converts a non-empty hash" do
         obj = described_class.ruby_to_object({foo: 1, bar: 2, baz: 3})
         expect(obj[:type]).to eq :ddwaf_obj_map
         expect(obj[:nbEntries]).to eq 3
+        expect(obj.input_truncated?).to eq(false)
         hash = (0...obj[:nbEntries]).each.with_object({}) do |i, h|
           ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
           o = Datadog::AppSec::WAF::LibDDWAF::Object.new(ptr)
@@ -135,6 +148,8 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             obj = described_class.ruby_to_object((1..6).to_a, max_container_size: max_container_size)
             expect(obj[:type]).to eq :ddwaf_obj_array
             expect(obj[:nbEntries]).to eq 3
+            expect(obj.input_truncated?).to eq(true)
+
             array = (0...obj[:nbEntries]).each.with_object([]) do |i, a|
               ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
               o = Datadog::AppSec::WAF::LibDDWAF::Object.new(ptr)
@@ -149,6 +164,8 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             obj = described_class.ruby_to_object({foo: 1, bar: 2, baz: 3, qux: 4}, max_container_size: max_container_size)
             expect(obj[:type]).to eq :ddwaf_obj_map
             expect(obj[:nbEntries]).to eq 3
+            expect(obj.input_truncated?).to eq(true)
+
             hash = (0...obj[:nbEntries]).each.with_object({}) do |i, h|
               ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
               o = Datadog::AppSec::WAF::LibDDWAF::Object.new(ptr)
@@ -167,6 +184,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             obj = described_class.ruby_to_object([1, [2, [3, [4]]]], max_container_depth: max_container_depth)
             expect(obj[:type]).to eq :ddwaf_obj_array
             expect(obj[:nbEntries]).to eq 2
+            expect(obj.input_truncated?).to eq(true)
 
             ptr1 = obj[:valueUnion][:array] + 0 * Datadog::AppSec::WAF::LibDDWAF::Object.size
             ptr2 = obj[:valueUnion][:array] + 1 * Datadog::AppSec::WAF::LibDDWAF::Object.size
@@ -212,6 +230,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             obj = described_class.ruby_to_object({foo: {bar: {baz: {qux: 4}}}}, max_container_depth: max_container_depth)
             expect(obj[:type]).to eq :ddwaf_obj_map
             expect(obj[:nbEntries]).to eq 1
+            expect(obj.input_truncated?).to eq(true)
 
             ptr = obj[:valueUnion][:array] + 0 * Datadog::AppSec::WAF::LibDDWAF::Object.size
             o = Datadog::AppSec::WAF::LibDDWAF::Object.new(ptr)
@@ -251,6 +270,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             expect(obj[:type]).to eq :ddwaf_obj_string
             expect(obj[:nbEntries]).to eq 10
             expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "fooooooooo"
+            expect(obj.input_truncated?).to eq(true)
           end
 
           it "converts a binary string up to the limit" do
@@ -258,6 +278,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             expect(obj[:type]).to eq :ddwaf_obj_string
             expect(obj[:nbEntries]).to eq 10
             expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "foo\x00barrrr"
+            expect(obj.input_truncated?).to eq(true)
           end
 
           it "converts a symbol up to the limit" do
@@ -265,6 +286,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             expect(obj[:type]).to eq :ddwaf_obj_string
             expect(obj[:nbEntries]).to eq 10
             expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "fooooooooo"
+            expect(obj.input_truncated?).to eq(true)
           end
 
           it "converts hash keys up to the limit" do
@@ -279,6 +301,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             k = o[:parameterName].read_bytes(l)
             expect(l).to eq 10
             expect(k).to eq "fooooooooo"
+            expect(obj.input_truncated?).to eq(true)
           end
         end
       end


### PR DESCRIPTION
**Motivation**
We want to know when the WAF input was truncated during object conversion to report this via telemetry in the tracer.

**Additional Notes**
None.

**How to test the change?**
Unit tests.

