### PR TITLE
Bump version to 1.24.1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 2025-08-15 v1.24.1.1.0
+
 ## Added
 
 - Add `LibDDWAF::Object#input_truncated?` method that returns true if the input object was truncated during conversion to libddwaf object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Changed
 
-- Change Handle#known_addresses to cache the result
+- Change `Handle#known_addresses` to cache the result
 
 # 2025-05-20 v1.24.1.0.0
 

--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -5,7 +5,7 @@ module Datadog
         BASE_STRING = "1.24.1"
         # NOTE: Every change to the `BASE_STRING` should be accompanied
         #       by a reset of the patch version in the `STRING` below.
-        STRING = "#{BASE_STRING}.0.3"
+        STRING = "#{BASE_STRING}.1.0"
         MINIMUM_RUBY_VERSION = "2.5"
       end
     end


### PR DESCRIPTION
**What does this PR do?**
It bumps the version of the gem to 1.24.1.1.0.

**Motivation**
We want to release a new version with caching in `Handle#known_addresses` and `LibDDWAF::Object.input_truncated?`.

**Additional Notes**
This is kinda like a minor bump, but we are not changing `libddwaf` version, that's why 1.24.1.1.0.

**How to test the change?**
CI.

