### PR TITLE
Rename LibDDWAF::Object truncate related methods

### DIFF
--- a/lib/datadog/appsec/waf/context.rb
+++ b/lib/datadog/appsec/waf/context.rb
@@ -83,7 +83,7 @@ module Datadog
             Converter.object_to_ruby(result_obj[:derivatives])
           )
 
-          if persistent_data_obj.input_truncated? || ephemeral_data_obj.input_truncated?
+          if persistent_data_obj.truncated? || ephemeral_data_obj.truncated?
             result.mark_input_truncated!
           end
 

--- a/lib/datadog/appsec/waf/converter.rb
+++ b/lib/datadog/appsec/waf/converter.rb
@@ -17,7 +17,7 @@ module Datadog
 
             max_index = max_container_size - 1 if max_container_size
             if max_container_depth == 0
-              top_obj&.mark_as_input_truncated!
+              top_obj&.mark_truncated!
             else
               val.each.with_index do |e, i|
                 member = Converter.ruby_to_object(
@@ -32,7 +32,7 @@ module Datadog
                 raise ConversionError, "Could not add to array object: #{e.inspect}" unless e_res
 
                 if max_index && i >= max_index
-                  (top_obj || obj).mark_as_input_truncated!
+                  (top_obj || obj).mark_truncated!
                   break val
                 end
               end
@@ -46,7 +46,7 @@ module Datadog
 
             max_index = max_container_size - 1 if max_container_size
             if max_container_depth == 0
-              top_obj&.mark_as_input_truncated!
+              top_obj&.mark_truncated!
             else
               val.each.with_index do |e, i|
                 # for Steep, which doesn't handle |(k, v), i|
@@ -55,7 +55,7 @@ module Datadog
 
                 if max_string_length && k.length > max_string_length
                   k = k.to_s[0, max_string_length]
-                  (top_obj || obj).mark_as_input_truncated!
+                  (top_obj || obj).mark_truncated!
                 end
                 member = Converter.ruby_to_object(
                   v,
@@ -69,7 +69,7 @@ module Datadog
                 raise ConversionError, "Could not add to map object: #{k.inspect} => #{v.inspect}" unless kv_res
 
                 if max_index && i >= max_index
-                  (top_obj || obj).mark_as_input_truncated!
+                  (top_obj || obj).mark_truncated!
                   break val
                 end
               end
@@ -81,7 +81,7 @@ module Datadog
             encoded_val = val.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
             if max_string_length && encoded_val.length > max_string_length
               encoded_val = encoded_val[0, max_string_length]
-              (top_obj || obj).mark_as_input_truncated!
+              (top_obj || obj).mark_truncated!
             end
             str = encoded_val.to_s
             res = LibDDWAF.ddwaf_object_stringl(obj, str, str.bytesize)
@@ -92,7 +92,7 @@ module Datadog
             obj = LibDDWAF::Object.new
             if max_string_length
               val = val.to_s[0, max_string_length]
-              (top_obj || obj).mark_as_input_truncated!
+              (top_obj || obj).mark_truncated!
             end
             str = val.to_s
             res = LibDDWAF.ddwaf_object_stringl(obj, str, str.bytesize)

--- a/lib/datadog/appsec/waf/lib_ddwaf.rb
+++ b/lib/datadog/appsec/waf/lib_ddwaf.rb
@@ -137,12 +137,12 @@ module Datadog
             :nbEntries, :uint64,
             :type, :ddwaf_obj_type
 
-          def input_truncated?
-            @input_truncated == true
+          def truncated?
+            @truncated == true
           end
 
-          def mark_as_input_truncated!
-            @input_truncated = true
+          def mark_truncated!
+            @truncated = true
           end
         end
 

--- a/sig/datadog/appsec/waf/lib_ddwaf.rbs
+++ b/sig/datadog/appsec/waf/lib_ddwaf.rbs
@@ -58,9 +58,9 @@ module Datadog
         end
 
         class Object < ::FFI::Struct[::FFI::AbstractMemory, untyped]
-          def input_truncated?: () -> bool
+          def truncated?: () -> bool
 
-          def mark_as_input_truncated!: () -> bool
+          def mark_truncated!: () -> bool
         end
 
         # setters

--- a/spec/datadog/appsec/waf/converter_spec.rb
+++ b/spec/datadog/appsec/waf/converter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 0
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq ""
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
       end
 
       it "converts an unhandled object" do
@@ -20,7 +20,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 0
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq ""
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
       end
 
       it "converts a boolean" do
@@ -32,7 +32,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 5
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "false"
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
       end
 
       it "converts a string" do
@@ -40,7 +40,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 3
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "foo"
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
       end
 
       it "converts a binary string" do
@@ -48,7 +48,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 7
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "foo\x00bar"
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
       end
 
       it "converts a symbol" do
@@ -56,7 +56,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 3
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "foo"
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
       end
 
       it "converts a positive integer" do
@@ -64,7 +64,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 2
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "42"
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
       end
 
       it "converts a negative integer" do
@@ -72,7 +72,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 3
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "-42"
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
       end
 
       it "converts a float" do
@@ -80,7 +80,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 17
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "3.141592653589793"
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
       end
 
       it "converts an empty array" do
@@ -88,14 +88,14 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_array
         expect(obj[:nbEntries]).to eq 0
         expect(obj[:valueUnion][:array].null?).to be true
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
       end
 
       it "converts a non-empty array" do
         obj = described_class.ruby_to_object((1..6).to_a)
         expect(obj[:type]).to eq :ddwaf_obj_array
         expect(obj[:nbEntries]).to eq 6
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
         array = (0...obj[:nbEntries]).each.with_object([]) do |i, a|
           ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
           o = Datadog::AppSec::WAF::LibDDWAF::Object.new(ptr)
@@ -111,14 +111,14 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
         expect(obj[:type]).to eq :ddwaf_obj_map
         expect(obj[:nbEntries]).to eq 0
         expect(obj[:valueUnion][:array].null?).to be true
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
       end
 
       it "converts a non-empty hash" do
         obj = described_class.ruby_to_object({foo: 1, bar: 2, baz: 3})
         expect(obj[:type]).to eq :ddwaf_obj_map
         expect(obj[:nbEntries]).to eq 3
-        expect(obj.input_truncated?).to eq(false)
+        expect(obj).not_to be_truncated
         hash = (0...obj[:nbEntries]).each.with_object({}) do |i, h|
           ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
           o = Datadog::AppSec::WAF::LibDDWAF::Object.new(ptr)
@@ -148,7 +148,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             obj = described_class.ruby_to_object((1..6).to_a, max_container_size: max_container_size)
             expect(obj[:type]).to eq :ddwaf_obj_array
             expect(obj[:nbEntries]).to eq 3
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
 
             array = (0...obj[:nbEntries]).each.with_object([]) do |i, a|
               ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
@@ -164,7 +164,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             obj = described_class.ruby_to_object({foo: 1, bar: 2, baz: 3, qux: 4}, max_container_size: max_container_size)
             expect(obj[:type]).to eq :ddwaf_obj_map
             expect(obj[:nbEntries]).to eq 3
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
 
             hash = (0...obj[:nbEntries]).each.with_object({}) do |i, h|
               ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
@@ -184,7 +184,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             obj = described_class.ruby_to_object([1, [2, [3, [4]]]], max_container_depth: max_container_depth)
             expect(obj[:type]).to eq :ddwaf_obj_array
             expect(obj[:nbEntries]).to eq 2
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
 
             ptr1 = obj[:valueUnion][:array] + 0 * Datadog::AppSec::WAF::LibDDWAF::Object.size
             ptr2 = obj[:valueUnion][:array] + 1 * Datadog::AppSec::WAF::LibDDWAF::Object.size
@@ -230,7 +230,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             obj = described_class.ruby_to_object({foo: {bar: {baz: {qux: 4}}}}, max_container_depth: max_container_depth)
             expect(obj[:type]).to eq :ddwaf_obj_map
             expect(obj[:nbEntries]).to eq 1
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
 
             ptr = obj[:valueUnion][:array] + 0 * Datadog::AppSec::WAF::LibDDWAF::Object.size
             o = Datadog::AppSec::WAF::LibDDWAF::Object.new(ptr)
@@ -270,7 +270,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             expect(obj[:type]).to eq :ddwaf_obj_string
             expect(obj[:nbEntries]).to eq 10
             expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "fooooooooo"
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
           end
 
           it "converts a binary string up to the limit" do
@@ -278,7 +278,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             expect(obj[:type]).to eq :ddwaf_obj_string
             expect(obj[:nbEntries]).to eq 10
             expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "foo\x00barrrr"
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
           end
 
           it "converts a symbol up to the limit" do
@@ -286,7 +286,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             expect(obj[:type]).to eq :ddwaf_obj_string
             expect(obj[:nbEntries]).to eq 10
             expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "fooooooooo"
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
           end
 
           it "converts hash keys up to the limit" do
@@ -301,7 +301,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             k = o[:parameterName].read_bytes(l)
             expect(l).to eq 10
             expect(k).to eq "fooooooooo"
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
           end
         end
       end
@@ -429,7 +429,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             obj = described_class.ruby_to_object((1..6).to_a, max_container_size: max_container_size, coerce: false)
             expect(obj[:type]).to eq :ddwaf_obj_array
             expect(obj[:nbEntries]).to eq 3
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
 
             array = (0...obj[:nbEntries]).each.with_object([]) do |i, a|
               ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
@@ -443,14 +443,14 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
           it "marks nested arrays exceeding limit as input truncated" do
             obj = described_class.ruby_to_object([(1..6).to_a], max_container_size: max_container_size, coerce: false)
             expect(obj[:type]).to eq :ddwaf_obj_array
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
           end
 
           it "converts a hash up to the limit" do
             obj = described_class.ruby_to_object({foo: 1, bar: 2, baz: 3, qux: 4}, max_container_size: max_container_size, coerce: false)
             expect(obj[:type]).to eq :ddwaf_obj_map
             expect(obj[:nbEntries]).to eq 3
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
 
             hash = (0...obj[:nbEntries]).each.with_object({}) do |i, h|
               ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
@@ -466,7 +466,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
           it "marks nested hashes exceeding limit as input truncated" do
             obj = described_class.ruby_to_object({some_key: {foo: 1, bar: 2, baz: 3, qux: 4}}, max_container_size: max_container_size, coerce: false)
             expect(obj[:type]).to eq :ddwaf_obj_map
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
           end
 
           it "marks hash with symbol keys exceeding length limit as input truncated" do
@@ -475,7 +475,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
 
             expect(obj[:type]).to eq :ddwaf_obj_map
             expect(obj[:nbEntries]).to eq 1
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
           end
 
           it "marks hash with string values exceeding length limit as input truncated" do
@@ -484,7 +484,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
 
             expect(obj[:type]).to eq :ddwaf_obj_map
             expect(obj[:nbEntries]).to eq 1
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
           end
 
           it "marks hash symbol values exceeding length limit as input truncated" do
@@ -493,7 +493,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
 
             expect(obj[:type]).to eq :ddwaf_obj_map
             expect(obj[:nbEntries]).to eq 1
-            expect(obj.input_truncated?).to eq(true)
+            expect(obj).to be_truncated
           end
         end
 


### PR DESCRIPTION
Slight renaming around truncation naming

