### PR TITLE
Upgrade to 1.25.1

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -13,6 +13,9 @@ ignore:
       # additional conversion to symbol which is extra overhead:
       # https://github.com/rubocop/rubocop/issues/13955
       - Performance/StringIdentifierArgument
+      # steep has annotation syntax which require immediate sign after the hash
+      # character. To avoid being too directive, I would let comments go loose.
+      - Layout/LeadingCommentSpace
 
   # This disables standardrb.
   - spec/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Changed
+
+- Change `LibDDWAF::Object#input_truncated?` to `LibDDWAF::Object#truncated?`
+- Change `LibDDWAF::Object#mark_as_input_truncated?` to `LibDDWAF::Object#mark_truncated?`
+
 # 2025-09-02 v1.24.1.2.0
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Unreleased
 
+## Added
+
+- Add `Result#keep?` method
+
 ## Changed
 
-- Change `LibDDWAF::Object#input_truncated?` to `LibDDWAF::Object#truncated?`
-- Change `LibDDWAF::Object#mark_as_input_truncated?` to `LibDDWAF::Object#mark_truncated?`
+- Change `LibDDWAF::Object#input_truncated?` to `LibDDWAF::Object#truncated?` method
+- Change `LibDDWAF::Object#mark_as_input_truncated?` to `LibDDWAF::Object#mark_truncated?` method
+- Change `Result` class initialization interface
+- Change `Result#timeout` to `Result#timeout?` method
 
 # 2025-09-02 v1.24.1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 - Change `LibDDWAF::Object#input_truncated?` to `LibDDWAF::Object#truncated?` method
 - Change `LibDDWAF::Object#mark_as_input_truncated?` to `LibDDWAF::Object#mark_truncated?` method
-- Change `Result` class initialization interface
 - Change `Result#timeout` to `Result#timeout?` method
+- Change `Result#derivatives` to `Result#attributes` method
+- Change `Result#total_runtime` to `Result#duration` method
 
 # 2025-09-02 v1.24.1.2.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,8 @@ gem "yard", "~> 0.9"
 
 platforms :mri do
   if RUBY_VERSION >= "3.1.0"
-    gem "rbs", "~> 3.6.1", require: false
-    gem "steep", "~> 1.8.1", require: false
+    gem "rbs", "~> 3.9.0", require: false
+    gem "steep", "~> 1.10.0", require: false
 
     # parallel 1.23 seems to annoy steep:
     # cannot load such file -- parallel/processor_count (LoadError)

--- a/lib/datadog/appsec/waf/context.rb
+++ b/lib/datadog/appsec/waf/context.rb
@@ -87,19 +87,9 @@ module Datadog
             result["actions"],
             result["attributes"],
             result["duration"],
-            result["timeout"]
+            result["timeout"],
+            result["keep"]
           )
-
-          # TODO: Add missing fields
-          #       * keep
-          #
-          # TODO: Re-order fields into that order (also `intinialize`)
-          #       * events
-          #       * actions
-          #       * attributes
-          #       * duration
-          #       * timeout
-          #       * keep
 
           if persistent_data_obj.input_truncated? || ephemeral_data_obj.input_truncated?
             result.mark_input_truncated!

--- a/lib/datadog/appsec/waf/context.rb
+++ b/lib/datadog/appsec/waf/context.rb
@@ -75,7 +75,6 @@ module Datadog
           code = LibDDWAF.ddwaf_run(@context_ptr, persistent_data_obj, ephemeral_data_obj, result_obj, timeout)
           result = Converter.object_to_ruby(result_obj) #: ::Hash[::String, WAF::data]
 
-          # TODO: Write test
           if result.nil?
             raise ConversionError, "Could not convert result into object: #{code}"
           end

--- a/lib/datadog/appsec/waf/context.rb
+++ b/lib/datadog/appsec/waf/context.rb
@@ -69,10 +69,12 @@ module Datadog
             raise ConversionError, "Could not convert ephemeral data: #{ephemeral_data.inspect}"
           end
 
-          result_obj = LibDDWAF::Result.new
+          result_obj = LibDDWAF::Object.new
           raise LibDDWAFError, "Could not create result object" if result_obj.null?
 
           code = LibDDWAF.ddwaf_run(@context_ptr, persistent_data_obj, ephemeral_data_obj, result_obj, timeout)
+
+          binding.irb
 
           result = Result.new(
             RESULT_CODE[code],
@@ -89,7 +91,7 @@ module Datadog
 
           result
         ensure
-          LibDDWAF.ddwaf_result_free(result_obj) if result_obj
+          LibDDWAF.ddwaf_object_free(result_obj) if result_obj
           LibDDWAF.ddwaf_object_free(ephemeral_data_obj) if ephemeral_data_obj
         end
 

--- a/lib/datadog/appsec/waf/context.rb
+++ b/lib/datadog/appsec/waf/context.rb
@@ -80,13 +80,13 @@ module Datadog
           end
 
           result = Result.new(
-            RESULT_CODE[code],
-            result["events"],
-            result["actions"],
-            result["attributes"],
-            result["duration"],   #: ::Integer
-            result["timeout"],    #: bool
-            result["keep"]        #: bool
+            status: RESULT_CODE[code],
+            events: result["events"],
+            actions: result["actions"],
+            attributes: result["attributes"],
+            duration: result["duration"], #: ::Integer
+            timeout: result["timeout"],   #: bool
+            keep: result["keep"]          #: bool
           )
 
           if persistent_data_obj.input_truncated? || ephemeral_data_obj.input_truncated?

--- a/lib/datadog/appsec/waf/context.rb
+++ b/lib/datadog/appsec/waf/context.rb
@@ -73,22 +73,21 @@ module Datadog
           raise LibDDWAFError, "Could not create result object" if result_obj.null?
 
           code = LibDDWAF.ddwaf_run(@context_ptr, persistent_data_obj, ephemeral_data_obj, result_obj, timeout)
-          result = Converter.object_to_ruby(result_obj)
+          result = Converter.object_to_ruby(result_obj) #: ::Hash[::String, WAF::data]
 
           # TODO: Write test
           if result.nil?
             raise ConversionError, "Could not convert result into object: #{code}"
           end
 
-          # TODO: Rewrite tests in lib_ddwaf.rb
           result = Result.new(
             RESULT_CODE[code],
             result["events"],
             result["actions"],
             result["attributes"],
-            result["duration"],
-            result["timeout"],
-            result["keep"]
+            result["duration"],   #: ::Integer
+            result["timeout"],    #: bool
+            result["keep"]        #: bool
           )
 
           if persistent_data_obj.input_truncated? || ephemeral_data_obj.input_truncated?

--- a/lib/datadog/appsec/waf/context.rb
+++ b/lib/datadog/appsec/waf/context.rb
@@ -89,7 +89,7 @@ module Datadog
             keep: result["keep"]          #: bool
           )
 
-          if persistent_data_obj.input_truncated? || ephemeral_data_obj.input_truncated?
+          if persistent_data_obj.truncated? || ephemeral_data_obj.truncated?
             result.mark_input_truncated!
           end
 

--- a/lib/datadog/appsec/waf/context.rb
+++ b/lib/datadog/appsec/waf/context.rb
@@ -84,10 +84,10 @@ module Datadog
           result = Result.new(
             RESULT_CODE[code],
             result["events"],
-            result["duration"],
-            result["timeout"],
             result["actions"],
-            result["attributes"]
+            result["attributes"],
+            result["duration"],
+            result["timeout"]
           )
 
           # TODO: Add missing fields

--- a/lib/datadog/appsec/waf/converter.rb
+++ b/lib/datadog/appsec/waf/converter.rb
@@ -170,7 +170,7 @@ module Datadog
               a << e # steep:ignore
             end
           when :ddwaf_obj_map
-            (0...obj[:nbEntries]).each.with_object({}) do |i, h|
+            (0...obj[:nbEntries]).each.with_object({}) do |i, h| #$ ::Hash[::String, WAF::data]
               ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
               o = Datadog::AppSec::WAF::LibDDWAF::Object.new(ptr)
               l = o[:parameterNameLength]

--- a/lib/datadog/appsec/waf/lib_ddwaf.rb
+++ b/lib/datadog/appsec/waf/lib_ddwaf.rb
@@ -253,21 +253,9 @@ module Datadog
         attach_function :ddwaf_context_init, [:ddwaf_handle], :ddwaf_context
         attach_function :ddwaf_context_destroy, [:ddwaf_context], :void
 
-        # Ruby representation of ddwaf_result
-        # See https://github.com/DataDog/libddwaf/blob/10e3a1dfc7bc9bb8ab11a09a9f8b6b339eaf3271/include/ddwaf.h#L154-L173
-        class Result < ::FFI::Struct
-          layout :timeout, :bool,
-            :events, Object,
-            :actions, Object,
-            :derivatives, Object,
-            :total_runtime, :uint64
-        end
-
-        typedef Result.by_ref, :ddwaf_result
         typedef :uint64, :timeout_us
 
-        attach_function :ddwaf_run, [:ddwaf_context, :ddwaf_object, :ddwaf_object, :ddwaf_result, :timeout_us], :ddwaf_ret_code, blocking: true
-        attach_function :ddwaf_result_free, [:ddwaf_result], :void
+        attach_function :ddwaf_run, [:ddwaf_context, :ddwaf_object, :ddwaf_object, :ddwaf_object, :timeout_us], :ddwaf_ret_code, blocking: true
 
         # logging
 

--- a/lib/datadog/appsec/waf/result.rb
+++ b/lib/datadog/appsec/waf/result.rb
@@ -6,20 +6,29 @@ module Datadog
       # Ruby representation of the ddwaf_result of a libddwaf run.
       # See https://github.com/DataDog/libddwaf/blob/8dbee187ff74a0aa25e1bcbdde51677f77930e1b/include/ddwaf.h#L277-L290
       class Result
-        attr_reader :status, :events, :actions, :derivatives, :total_runtime, :timeout
+        attr_reader :status, :events, :actions, :derivatives, :total_runtime
 
-        def initialize(status, events, actions, derivatives, total_runtime, timeout)
+        def initialize(status, events, actions, derivatives, total_runtime, timeout, keep)
           @status = status
           @events = events
           @actions = actions
           @derivatives = derivatives
           @total_runtime = total_runtime
           @timeout = timeout
+          @keep = keep
           @input_truncated = false
         end
 
         def mark_input_truncated!
           @input_truncated = true
+        end
+
+        def timeout?
+          @timeout
+        end
+
+        def keep?
+          @keep
         end
 
         def input_truncated?
@@ -34,6 +43,7 @@ module Datadog
             derivatives: @derivatives,
             total_runtime: @total_runtime,
             timeout: @timeout,
+            keep: @keep,
             input_truncated: @input_truncated
           }
         end

--- a/lib/datadog/appsec/waf/result.rb
+++ b/lib/datadog/appsec/waf/result.rb
@@ -6,14 +6,14 @@ module Datadog
       # Ruby representation of the ddwaf_result of a libddwaf run.
       # See https://github.com/DataDog/libddwaf/blob/8dbee187ff74a0aa25e1bcbdde51677f77930e1b/include/ddwaf.h#L277-L290
       class Result
-        attr_reader :status, :events, :actions, :derivatives, :total_runtime
+        attr_reader :status, :events, :actions, :attributes, :duration
 
-        def initialize(status, events, actions, derivatives, total_runtime, timeout, keep)
+        def initialize(status, events, actions, attributes, duration, timeout, keep)
           @status = status
           @events = events
           @actions = actions
-          @derivatives = derivatives
-          @total_runtime = total_runtime
+          @attributes = attributes
+          @duration = duration
           @timeout = timeout
           @keep = keep
           @input_truncated = false
@@ -40,8 +40,8 @@ module Datadog
             status: @status,
             events: @events,
             actions: @actions,
-            derivatives: @derivatives,
-            total_runtime: @total_runtime,
+            attributes: @attributes,
+            duration: @duration,
             timeout: @timeout,
             keep: @keep,
             input_truncated: @input_truncated

--- a/lib/datadog/appsec/waf/result.rb
+++ b/lib/datadog/appsec/waf/result.rb
@@ -8,7 +8,7 @@ module Datadog
       class Result
         attr_reader :status, :events, :actions, :attributes, :duration
 
-        def initialize(status, events, actions, attributes, duration, timeout, keep)
+        def initialize(status:, events:, actions:, attributes:, duration:, timeout:, keep:)
           @status = status
           @events = events
           @actions = actions

--- a/lib/datadog/appsec/waf/result.rb
+++ b/lib/datadog/appsec/waf/result.rb
@@ -6,15 +6,15 @@ module Datadog
       # Ruby representation of the ddwaf_result of a libddwaf run.
       # See https://github.com/DataDog/libddwaf/blob/8dbee187ff74a0aa25e1bcbdde51677f77930e1b/include/ddwaf.h#L277-L290
       class Result
-        attr_reader :status, :events, :total_runtime, :timeout, :actions, :derivatives
+        attr_reader :status, :events, :actions, :derivatives, :total_runtime, :timeout
 
-        def initialize(status, events, total_runtime, timeout, actions, derivatives)
+        def initialize(status, events, actions, derivatives, total_runtime, timeout)
           @status = status
           @events = events
-          @total_runtime = total_runtime
-          @timeout = timeout
           @actions = actions
           @derivatives = derivatives
+          @total_runtime = total_runtime
+          @timeout = timeout
           @input_truncated = false
         end
 
@@ -30,10 +30,11 @@ module Datadog
           {
             status: @status,
             events: @events,
+            actions: @actions,
+            derivatives: @derivatives,
             total_runtime: @total_runtime,
             timeout: @timeout,
-            actions: @actions,
-            derivatives: @derivatives
+            input_truncated: @input_truncated
           }
         end
       end

--- a/lib/datadog/appsec/waf/result.rb
+++ b/lib/datadog/appsec/waf/result.rb
@@ -4,7 +4,7 @@ module Datadog
   module AppSec
     module WAF
       # Ruby representation of the ddwaf_result of a libddwaf run.
-      # See https://github.com/DataDog/libddwaf/blob/10e3a1dfc7bc9bb8ab11a09a9f8b6b339eaf3271/include/ddwaf.h#L159-L173
+      # See https://github.com/DataDog/libddwaf/blob/8dbee187ff74a0aa25e1bcbdde51677f77930e1b/include/ddwaf.h#L277-L290
       class Result
         attr_reader :status, :events, :total_runtime, :timeout, :actions, :derivatives
 

--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -2,10 +2,10 @@ module Datadog
   module AppSec
     module WAF
       module VERSION
-        BASE_STRING = "1.24.1"
+        BASE_STRING = "1.25.1"
         # NOTE: Every change to the `BASE_STRING` should be accompanied
         #       by a reset of the patch version in the `STRING` below.
-        STRING = "#{BASE_STRING}.2.0"
+        STRING = "#{BASE_STRING}.0.0"
         MINIMUM_RUBY_VERSION = "2.5"
       end
     end

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -5,14 +5,14 @@ module Datadog
       type known_addresses = ::Array[::String]
       type diagnostics = ::Hash[::String, untyped]
 
-      def self.version: () -> ::String
+      def self?.version: () -> ::String
 
       self.@logger: ::Logger
       self.@log_callback: LibDDWAF::ddwaf_log_cb
 
-      def self.log_callback: (LibDDWAF::ddwaf_log_level, ::String, ::String, ::Integer, ::FFI::Pointer, ::Integer) -> void
-      def self.logger: () -> ::Logger
-      def self.logger=: (::Logger logger) -> void
+      def self?.log_callback: (LibDDWAF::ddwaf_log_level, ::String, ::String, ::Integer, ::FFI::Pointer, ::Integer) -> void
+      def self?.logger: () -> ::Logger
+      def self?.logger=: (::Logger logger) -> void
     end
   end
 end

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module AppSec
     module WAF
-      type data = String | Symbol | Integer | Float | TrueClass | FalseClass | Array[data] | Hash[(String | Symbol | nil), data] | nil
+      type data = nil | bool | ::String | ::Symbol | ::Integer | ::Float | ::Array[data] | ::Hash[(::String | ::Symbol | nil), data]
       type known_addresses = ::Array[::String]
       type diagnostics = ::Hash[::String, untyped]
 

--- a/sig/datadog/appsec/waf/converter.rbs
+++ b/sig/datadog/appsec/waf/converter.rbs
@@ -2,9 +2,9 @@ module Datadog
   module AppSec
     module WAF
       module Converter
-        def self.ruby_to_object: (top val, ?max_container_size: ::Integer?, ?max_container_depth: ::Integer?, ?max_string_length: ::Integer?, ?top_obj: LibDDWAF::Object?, ?coerce: bool?) -> LibDDWAF::Object
+        def self?.ruby_to_object: (top val, ?max_container_size: ::Integer?, ?max_container_depth: ::Integer?, ?max_string_length: ::Integer?, ?top_obj: LibDDWAF::Object?, ?coerce: bool?) -> LibDDWAF::Object
 
-        def self.object_to_ruby: (LibDDWAF::Object obj) -> WAF::data
+        def self?.object_to_ruby: (LibDDWAF::Object obj) -> WAF::data
       end
     end
   end

--- a/sig/datadog/appsec/waf/lib_ddwaf.rbs
+++ b/sig/datadog/appsec/waf/lib_ddwaf.rbs
@@ -139,11 +139,7 @@ module Datadog
         def self.ddwaf_context_init: (::FFI::Pointer) -> ::FFI::Pointer
         def self.ddwaf_context_destroy: (::FFI::Pointer) -> void
 
-        class Result < ::FFI::Struct[::FFI::AbstractMemory, untyped]
-        end
-
-        def self.ddwaf_run: (::FFI::Pointer, Object, Object, Result, ::Integer) -> ::Symbol
-        def self.ddwaf_result_free: (Result) -> void
+        def self.ddwaf_run: (::FFI::Pointer, Object, Object, Object, ::Integer) -> ::Symbol
 
         # logging
 

--- a/sig/datadog/appsec/waf/result.rbs
+++ b/sig/datadog/appsec/waf/result.rbs
@@ -28,7 +28,7 @@ module Datadog
 
         attr_reader duration: ::Integer
 
-        def initialize: (::Symbol status, WAF::data events, WAF::data actions, WAF::data derivatives, ::Integer total_runtime, bool timeout, bool keep) -> void
+        def initialize: (::Symbol status, WAF::data events, WAF::data actions, WAF::data attributes, ::Integer duration, bool timeout, bool keep) -> void
 
         def mark_input_truncated!: () -> bool
 

--- a/sig/datadog/appsec/waf/result.rbs
+++ b/sig/datadog/appsec/waf/result.rbs
@@ -6,13 +6,15 @@ module Datadog
 
         @events: WAF::data
 
-        @total_runtime: ::Float
+        @actions: WAF::data
+
+        @attributes: WAF::data
+
+        @duration: ::Integer
 
         @timeout: bool
 
-        @actions: WAF::data
-
-        @derivatives: WAF::data
+        @keep: bool
 
         @input_truncated: bool
 
@@ -20,19 +22,23 @@ module Datadog
 
         attr_reader events: WAF::data
 
-        attr_reader total_runtime: ::Float
-
-        attr_reader timeout: bool
-
         attr_reader actions: WAF::data
 
-        attr_reader derivatives: WAF::data
+        attr_reader attributes: WAF::data
 
-        def initialize: (::Symbol status, WAF::data events, ::Float total_runtime, bool timeout, WAF::data actions, WAF::data derivatives) -> void
+        attr_reader duration: ::Integer
+
+        def initialize: (::Symbol status, WAF::data events, WAF::data actions, WAF::data derivatives, ::Integer total_runtime, bool timeout, bool keep) -> void
 
         def mark_input_truncated!: () -> bool
 
+        def timeout?: () -> bool
+
+        def keep?: () -> bool
+
         def input_truncated?: () -> bool
+
+        def to_h: () -> ::Hash[::Symbol, WAF::data]
       end
     end
   end

--- a/sig/datadog/appsec/waf/result.rbs
+++ b/sig/datadog/appsec/waf/result.rbs
@@ -28,7 +28,15 @@ module Datadog
 
         attr_reader duration: ::Integer
 
-        def initialize: (::Symbol status, WAF::data events, WAF::data actions, WAF::data attributes, ::Integer duration, bool timeout, bool keep) -> void
+        def initialize: (
+          status: ::Symbol,
+          events: WAF::data,
+          actions: WAF::data,
+          attributes: WAF::data,
+          duration: ::Integer,
+          timeout: bool,
+          keep: bool
+        ) -> void
 
         def mark_input_truncated!: () -> bool
 

--- a/spec/datadog/appsec/waf/context_spec.rb
+++ b/spec/datadog/appsec/waf/context_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe Datadog::AppSec::WAF::Context do
         expect(result).not_to be_timeout
         expect(result.status).to eq(:ok)
         expect(result.events).to eq([])
-        expect(result.total_runtime).to be >= 0
+        expect(result.duration).to be >= 0
         expect(result.actions).to eq({})
-        expect(result.derivatives).to eq({})
+        expect(result.attributes).to eq({})
       end
     end
 
@@ -56,9 +56,9 @@ RSpec.describe Datadog::AppSec::WAF::Context do
         expect(result).not_to be_timeout
         expect(result.status).to eq(:ok)
         expect(result.events).to eq([])
-        expect(result.total_runtime).to be >= 0
+        expect(result.duration).to be >= 0
         expect(result.actions).to eq({})
-        expect(result.derivatives).to eq({})
+        expect(result.attributes).to eq({})
       end
     end
 
@@ -69,9 +69,9 @@ RSpec.describe Datadog::AppSec::WAF::Context do
         expect(result).not_to be_timeout
         expect(result.status).to eq(:match)
         expect(result.events).to match_array([{"rule" => anything, "rule_matches" => anything}])
-        expect(result.total_runtime).to be >= 0
+        expect(result.duration).to be >= 0
         expect(result.actions).to eq({"block_request" => {"grpc_status_code" => "10", "status_code" => "403", "type" => "auto"}})
-        expect(result.derivatives).to eq({})
+        expect(result.attributes).to eq({})
       end
     end
 
@@ -82,9 +82,9 @@ RSpec.describe Datadog::AppSec::WAF::Context do
         expect(result).not_to be_timeout
         expect(result.status).to eq(:match)
         expect(result.events).to match_array([{"rule" => anything, "rule_matches" => anything}])
-        expect(result.total_runtime).to be >= 0
+        expect(result.duration).to be >= 0
         expect(result.actions).to eq({"block_request" => {"grpc_status_code" => "10", "status_code" => "403", "type" => "auto"}})
-        expect(result.derivatives).to eq({})
+        expect(result.attributes).to eq({})
       end
     end
 
@@ -188,7 +188,7 @@ RSpec.describe Datadog::AppSec::WAF::Context do
       end
 
       context "with schema extraction" do
-        it "populates derivatives" do
+        it "populates attributes" do
           waf_args = {
             "server.request.query" => {
               "hello" => "EMBED"
@@ -202,13 +202,13 @@ RSpec.describe Datadog::AppSec::WAF::Context do
 
           aggregate_failures("result") do
             expect(result.status).to eq :ok
-            expect(result.derivatives).to eq({"_dd.appsec.s.req.query" => [{"hello" => [8]}]})
+            expect(result.attributes).to eq({"_dd.appsec.s.req.query" => [{"hello" => [8]}]})
           end
         end
       end
 
       context "without schema extraction" do
-        it "populates derivatives" do
+        it "populates attributes" do
           waf_args = {
             "server.request.query" => {
               "hello" => "EMBED"
@@ -222,7 +222,7 @@ RSpec.describe Datadog::AppSec::WAF::Context do
 
           aggregate_failures("result") do
             expect(result.status).to eq :ok
-            expect(result.derivatives).to be_empty
+            expect(result.attributes).to be_empty
           end
         end
       end

--- a/spec/datadog/appsec/waf/context_spec.rb
+++ b/spec/datadog/appsec/waf/context_spec.rb
@@ -96,9 +96,9 @@ RSpec.describe Datadog::AppSec::WAF::Context do
     it "raises LibDDWAF::Error when context has been finalized" do
       context.finalize!
 
-      expect do
-        context.run({}, {value2: ["rule1"]})
-      end.to raise_error(Datadog::AppSec::WAF::InstanceFinalizedError, /Cannot use WAF context after it has been finalized/)
+      expect { context.run({}, {value2: ["rule1"]}) }.to raise_error(
+        Datadog::AppSec::WAF::InstanceFinalizedError, /Cannot use WAF context after it has been finalized/
+      )
     end
 
     it "catches a match with a non UTF-8 string" do
@@ -225,6 +225,19 @@ RSpec.describe Datadog::AppSec::WAF::Context do
             expect(result.attributes).to be_empty
           end
         end
+      end
+    end
+
+    context "when result conversion failed" do
+      before do
+        allow(Datadog::AppSec::WAF::Converter).to receive(:object_to_ruby)
+          .and_return(nil)
+      end
+
+      it "raises exception" do
+        expect { context.run({}, {}) }.to raise_error(
+          Datadog::AppSec::WAF::ConversionError, /Could not convert result into object/
+        )
       end
     end
   end

--- a/spec/datadog/appsec/waf/context_spec.rb
+++ b/spec/datadog/appsec/waf/context_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe Datadog::AppSec::WAF::Context do
       result = context.run({value1: ["rule1"]}, {})
 
       aggregate_failures("result") do
+        expect(result).not_to be_timeout
         expect(result.status).to eq(:ok)
         expect(result.events).to eq([])
-        expect(result.total_runtime).to be_positive
-        expect(result.timeout).to eq(false)
+        expect(result.total_runtime).to be >= 0
         expect(result.actions).to eq({})
         expect(result.derivatives).to eq({})
       end
@@ -53,10 +53,10 @@ RSpec.describe Datadog::AppSec::WAF::Context do
       result = context.run({}, {value1: ["rule1"]})
 
       aggregate_failures("result") do
+        expect(result).not_to be_timeout
         expect(result.status).to eq(:ok)
         expect(result.events).to eq([])
-        expect(result.total_runtime).to be_positive
-        expect(result.timeout).to eq(false)
+        expect(result.total_runtime).to be >= 0
         expect(result.actions).to eq({})
         expect(result.derivatives).to eq({})
       end
@@ -66,10 +66,10 @@ RSpec.describe Datadog::AppSec::WAF::Context do
       result = context.run({value2: ["rule1"]}, {})
 
       aggregate_failures("result") do
+        expect(result).not_to be_timeout
         expect(result.status).to eq(:match)
         expect(result.events).to match_array([{"rule" => anything, "rule_matches" => anything}])
-        expect(result.total_runtime).to be_positive
-        expect(result.timeout).to eq(false)
+        expect(result.total_runtime).to be >= 0
         expect(result.actions).to eq({"block_request" => {"grpc_status_code" => "10", "status_code" => "403", "type" => "auto"}})
         expect(result.derivatives).to eq({})
       end
@@ -79,10 +79,10 @@ RSpec.describe Datadog::AppSec::WAF::Context do
       result = context.run({}, {value2: ["rule1"]})
 
       aggregate_failures("result") do
+        expect(result).not_to be_timeout
         expect(result.status).to eq(:match)
         expect(result.events).to match_array([{"rule" => anything, "rule_matches" => anything}])
-        expect(result.total_runtime).to be_positive
-        expect(result.timeout).to eq(false)
+        expect(result.total_runtime).to be >= 0
         expect(result.actions).to eq({"block_request" => {"grpc_status_code" => "10", "status_code" => "403", "type" => "auto"}})
         expect(result.derivatives).to eq({})
       end

--- a/spec/datadog/appsec/waf/context_stress_test_spec.rb
+++ b/spec/datadog/appsec/waf/context_stress_test_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Datadog::AppSec::WAF::Context, stress_tests: true do
             ephemeral_data[:value3] = [i]
             waf_result = context.run({}, ephemeral_data, 10_000_000)
             mutex.synchronize do
-              if waf_result.timeout
+              if waf_result.timeout?
                 if i.even?
                   result[:timeout_match] += 1
                 else

--- a/spec/datadog/appsec/waf/lib_ddwaf_spec.rb
+++ b/spec/datadog/appsec/waf/lib_ddwaf_spec.rb
@@ -810,104 +810,132 @@ RSpec.describe Datadog::AppSec::WAF::LibDDWAF do
 
     it "triggers a monitoring rule" do
       described_class.ddwaf_builder_add_or_update_config(builder, "some/path", 9, rule1, diagnostics_obj)
+
       handle = described_class.ddwaf_builder_build_instance(builder)
-      expect(handle.null?).to be false
+      expect(handle).not_to be_null
 
       context = described_class.ddwaf_context_init(handle)
-      expect(context.null?).to be false
+      expect(context).not_to be_null
 
-      result = described_class::Result.new
+      result = described_class::Object.new
       code = described_class.ddwaf_run(context, input, empty_input, result, timeout_usec)
 
       expect(code).to eq :ddwaf_match
-      expect(result[:timeout]).to eq false
-      expect(result[:events]).to be_a described_class::Object
-      expect(result[:actions]).to be_a described_class::Object
-      expect(described_class.ddwaf_object_size(result[:actions])).to eq 0
+      expect(result).to be_a(described_class::Object)
+
+      result = Datadog::AppSec::WAF::Converter.object_to_ruby(result)
+      expect(result["events"]).to be_a(Array)
+      expect(result["actions"]).to be_a(Hash)
+      expect(result["timeout"]).to eq(false)
+
+      expect(result["actions"].size).to be_zero
     end
 
     it "does not trigger" do
       described_class.ddwaf_builder_add_or_update_config(builder, "some/path", 9, rule2, diagnostics_obj)
       handle = described_class.ddwaf_builder_build_instance(builder)
-      expect(handle.null?).to be false
+      expect(handle).not_to be_null
 
       context = described_class.ddwaf_context_init(handle)
-      result = described_class::Result.new
+      expect(context).not_to be_null
+
+      result = described_class::Object.new
       code = described_class.ddwaf_run(context, input, empty_input, result, timeout_usec)
+
       expect(code).to eq :ddwaf_ok
-      expect(result[:timeout]).to eq false
-      expect(result[:events]).to be_a described_class::Object
-      expect(result[:actions]).to be_a described_class::Object
-      expect(described_class.ddwaf_object_size(result[:actions])).to eq 0
+      expect(result).to be_a(described_class::Object)
+
+      result = Datadog::AppSec::WAF::Converter.object_to_ruby(result)
+      expect(result["events"]).to be_a(Array)
+      expect(result["actions"]).to be_a(Hash)
+      expect(result["timeout"]).to eq(false)
+      expect(result["actions"].size).to be_zero
     end
 
     it "does not trigger a monitoring rule due to timeout" do
       described_class.ddwaf_builder_add_or_update_config(builder, "some/path", 9, rule1, diagnostics_obj)
       handle = described_class.ddwaf_builder_build_instance(builder)
-      expect(handle.null?).to be false
+      expect(handle).not_to be_null
 
       context = described_class.ddwaf_context_init(handle)
-      expect(context.null?).to be false
+      expect(context).not_to be_null
 
-      result = described_class::Result.new
+      result = described_class::Object.new
       code = described_class.ddwaf_run(context, input, empty_input, result, 1)
 
       expect(code).to eq :ddwaf_ok
-      expect(result[:timeout]).to eq true
-      expect(result[:events]).to be_a described_class::Object
-      expect(result[:actions]).to be_a described_class::Object
-      expect(described_class.ddwaf_object_size(result[:actions])).to eq 0
+      expect(result).to be_a(described_class::Object)
+
+      result = Datadog::AppSec::WAF::Converter.object_to_ruby(result)
+      expect(result["events"]).to be_a(Array)
+      expect(result["actions"]).to be_a(Hash)
+      expect(result["timeout"]).to eq(true)
+      expect(result["actions"].size).to be_zero
     end
 
     it "triggers a known attack" do
       described_class.ddwaf_builder_add_or_update_config(builder, "some/path", 9, rule3, diagnostics_obj)
       handle = described_class.ddwaf_builder_build_instance(builder)
-      expect(handle.null?).to be false
+      expect(handle).not_to be_null
 
       context = described_class.ddwaf_context_init(handle)
-      result = described_class::Result.new
+      expect(context).not_to be_null
+
+      result = described_class::Object.new
       code = described_class.ddwaf_run(context, attack, empty_input, result, timeout_usec)
+
       expect(code).to eq :ddwaf_match
-      expect(result[:timeout]).to eq false
-      expect(result[:events]).to be_a described_class::Object
-      expect(result[:actions]).to be_a described_class::Object
-      expect(described_class.ddwaf_object_size(result[:actions])).to eq 0
+      expect(result).to be_a(described_class::Object)
+
+      result = Datadog::AppSec::WAF::Converter.object_to_ruby(result)
+      expect(result["events"]).to be_a(Array)
+      expect(result["actions"]).to be_a(Hash)
+      expect(result["timeout"]).to eq(false)
+      expect(result["actions"].size).to be_zero
     end
 
     it "triggers a known actionable attack" do
       described_class.ddwaf_builder_add_or_update_config(builder, "some/path", 9, rule5, diagnostics_obj)
       handle = described_class.ddwaf_builder_build_instance(builder)
-      expect(handle.null?).to be false
+      expect(handle).not_to be_null
 
       context = described_class.ddwaf_context_init(handle)
-      result = described_class::Result.new
+      expect(context).not_to be_null
+
+      result = described_class::Object.new
       code = described_class.ddwaf_run(context, block, empty_input, result, timeout_usec)
+
       expect(code).to eq :ddwaf_match
-      expect(result[:timeout]).to eq false
-      expect(result[:events]).to be_a described_class::Object
-      expect(result[:actions]).to be_a described_class::Object
-      expect(described_class.ddwaf_object_size(result[:actions])).to eq 4
-      # TODO: not sure why libddwaf reverses actions
-      actions = Datadog::AppSec::WAF::Converter.object_to_ruby(result[:actions]).keys
-      expect(actions).to eq ["block", "extract_schema", "stacktrace", "unblock"].reverse
+      expect(result).to be_a(described_class::Object)
+
+      result = Datadog::AppSec::WAF::Converter.object_to_ruby(result)
+      expect(result["events"]).to be_a(Array)
+      expect(result["actions"]).to be_a(Hash)
+      expect(result["timeout"]).to eq(false)
+      expect(result["actions"].size).to eq(4)
+      expect(result["actions"].keys).to eq(["unblock", "stacktrace", "extract_schema", "block"])
     end
 
     it "silently drops invalid or unknown actions on actionable attack" do
       described_class.ddwaf_builder_add_or_update_config(builder, "some/path", 9, invalid_action_rule, diagnostics_obj)
       handle = described_class.ddwaf_builder_build_instance(builder)
-      expect(handle.null?).to be false
+      expect(handle).not_to be_null
 
       context = described_class.ddwaf_context_init(handle)
-      result = described_class::Result.new
-      code = described_class.ddwaf_run(context, block, empty_input, result, timeout_usec)
-      expect(code).to eq :ddwaf_match
-      expect(result[:timeout]).to eq false
-      expect(result[:events]).to be_a described_class::Object
-      expect(result[:actions]).to be_a described_class::Object
-      expect(described_class.ddwaf_object_size(result[:actions])).to eq 2
+      expect(context).not_to be_null
 
-      actions = Datadog::AppSec::WAF::Converter.object_to_ruby(result[:actions]).keys
-      expect(actions).to eq ["unblock", "block"]
+      result = described_class::Object.new
+      code = described_class.ddwaf_run(context, block, empty_input, result, timeout_usec)
+
+      expect(code).to eq :ddwaf_match
+      expect(result).to be_a(described_class::Object)
+
+      result = Datadog::AppSec::WAF::Converter.object_to_ruby(result)
+      expect(result["events"]).to be_a(Array)
+      expect(result["actions"]).to be_a(Hash)
+      expect(result["timeout"]).to eq(false)
+      expect(result["actions"].size).to eq(2)
+      expect(result["actions"].keys).to eq(["unblock", "block"])
     end
   end
 end

--- a/spec/datadog/appsec/waf/result_spec.rb
+++ b/spec/datadog/appsec/waf/result_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Datadog::AppSec::WAF::Result do
       ]
     end
 
-    let(:result) { described_class.new(:match, events, actions, {}, 286_125, false) }
+    let(:result) { described_class.new(:match, events, actions, {}, 286_125, false, true) }
 
     it "converts to Hash" do
       expect(result.to_h).to eq({
@@ -41,13 +41,14 @@ RSpec.describe Datadog::AppSec::WAF::Result do
         derivatives: {},
         total_runtime: 286_125,
         timeout: false,
+        keep: true,
         input_truncated: false
       })
     end
   end
 
   describe "#input_truncated?" do
-    subject(:result) { described_class.new(:ok, [], 0, false, {}, {}) }
+    subject(:result) { described_class.new(:ok, [], {}, {}, 0, false, false) }
 
     context "when input was not truncated" do
       it { expect(result).not_to be_input_truncated }

--- a/spec/datadog/appsec/waf/result_spec.rb
+++ b/spec/datadog/appsec/waf/result_spec.rb
@@ -31,7 +31,17 @@ RSpec.describe Datadog::AppSec::WAF::Result do
       ]
     end
 
-    let(:result) { described_class.new(:match, events, actions, {}, 286_125, false, true) }
+    let(:result) do
+      described_class.new(
+        status: :match,
+        events: events,
+        actions: actions,
+        attributes: {},
+        duration: 286_125,
+        timeout: false,
+        keep: true
+      )
+    end
 
     it "converts to Hash" do
       expect(result.to_h).to eq({
@@ -48,7 +58,17 @@ RSpec.describe Datadog::AppSec::WAF::Result do
   end
 
   describe "#input_truncated?" do
-    subject(:result) { described_class.new(:ok, [], {}, {}, 0, false, false) }
+    let(:result) do
+      described_class.new(
+        status: :ok,
+        events: [],
+        actions: {},
+        attributes: {},
+        duration: 0,
+        timeout: false,
+        keep: false
+      )
+    end
 
     context "when input was not truncated" do
       it { expect(result).not_to be_input_truncated }

--- a/spec/datadog/appsec/waf/result_spec.rb
+++ b/spec/datadog/appsec/waf/result_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe Datadog::AppSec::WAF::Result do
         status: :match,
         events: events,
         actions: actions,
-        derivatives: {},
-        total_runtime: 286_125,
+        attributes: {},
+        duration: 286_125,
         timeout: false,
         keep: true,
         input_truncated: false

--- a/spec/datadog/appsec/waf/result_spec.rb
+++ b/spec/datadog/appsec/waf/result_spec.rb
@@ -31,16 +31,17 @@ RSpec.describe Datadog::AppSec::WAF::Result do
       ]
     end
 
-    let(:result) { described_class.new(:match, events, 286_125, false, actions, {}) }
+    let(:result) { described_class.new(:match, events, actions, {}, 286_125, false) }
 
     it "converts to Hash" do
       expect(result.to_h).to eq({
         status: :match,
         events: events,
-        timeout: false,
-        total_runtime: 286_125,
         actions: actions,
-        derivatives: {}
+        derivatives: {},
+        total_runtime: 286_125,
+        timeout: false,
+        input_truncated: false
       })
     end
   end


### PR DESCRIPTION
**What does this PR do?**

An upgrade to [libddwaf 1.25.1](https://github.com/DataDog/libddwaf/blob/master/UPGRADING.md#upgrading-from-124x-to-1250) and general overhaul of broken type specs, naming and outdated development gems.

**Motivation**

The overhaul during a breaking change is easier to incorporate into the PR, so I did it.

**Additional Notes**

None.

**How to test the change?**

CI should cover most of the cases.