### PR TITLE
Fix conversion for a Hash with nil key

### DIFF
--- a/lib/datadog/appsec/waf/converter.rb
+++ b/lib/datadog/appsec/waf/converter.rb
@@ -78,7 +78,7 @@ module Datadog
             obj = LibDDWAF::Object.new
             encoded_val = val.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
             if max_string_length && encoded_val.length > max_string_length
-              encoded_val = encoded_val[0, max_string_length].to_s
+              encoded_val = encoded_val[0, max_string_length] #: String
               (top_obj || obj).mark_truncated!
             end
             res = LibDDWAF.ddwaf_object_stringl(obj, encoded_val, encoded_val.bytesize)
@@ -89,7 +89,7 @@ module Datadog
             obj = LibDDWAF::Object.new
             str = val.to_s
             if max_string_length && str.length > max_string_length
-              str = str[0, max_string_length].to_s
+              str = str[0, max_string_length] #: String
               (top_obj || obj).mark_truncated!
             end
             res = LibDDWAF.ddwaf_object_stringl(obj, str, str.bytesize)

--- a/lib/datadog/appsec/waf/converter.rb
+++ b/lib/datadog/appsec/waf/converter.rb
@@ -53,7 +53,7 @@ module Datadog
                 k = e[0]
                 v = e[1]
 
-                if max_string_length && k.length > max_string_length
+                if max_string_length && k && k.length > max_string_length
                   k = k.to_s[0, max_string_length]
                   (top_obj || obj).mark_truncated!
                 end

--- a/lib/datadog/appsec/waf/converter.rb
+++ b/lib/datadog/appsec/waf/converter.rb
@@ -50,11 +50,11 @@ module Datadog
             else
               val.each.with_index do |e, i|
                 # for Steep, which doesn't handle |(k, v), i|
-                k = e[0]
+                k = e[0].to_s
                 v = e[1]
 
-                if max_string_length && k && k.length > max_string_length
-                  k = k.to_s[0, max_string_length]
+                if max_string_length && k.length > max_string_length
+                  k = k[0, max_string_length]
                   (top_obj || obj).mark_truncated!
                 end
                 member = Converter.ruby_to_object(
@@ -65,8 +65,8 @@ module Datadog
                   top_obj: top_obj || obj,
                   coerce: coerce
                 )
-                kv_res = LibDDWAF.ddwaf_object_map_addl(obj, k.to_s, k.to_s.bytesize, member)
-                raise ConversionError, "Could not add to map object: #{k.inspect} => #{v.inspect}" unless kv_res
+                kv_res = LibDDWAF.ddwaf_object_map_addl(obj, k, k.bytesize, member)
+                raise ConversionError, "Could not add to map object: #{e[0].inspect} => #{v.inspect}" unless kv_res
 
                 if max_index && i >= max_index
                   (top_obj || obj).mark_truncated!
@@ -90,11 +90,11 @@ module Datadog
             obj
           when Symbol
             obj = LibDDWAF::Object.new
-            if max_string_length
-              val = val.to_s[0, max_string_length]
+            str = val.to_s
+            if max_string_length && str.length > max_string_length
+              str = str[0, max_string_length].to_s
               (top_obj || obj).mark_truncated!
             end
-            str = val.to_s
             res = LibDDWAF.ddwaf_object_stringl(obj, str, str.bytesize)
             raise ConversionError, "Could not convert into object: #{val.inspect}" if res.null?
 

--- a/libddwaf.gemspec
+++ b/libddwaf.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email = ["dev@datadoghq.com"]
 
   spec.summary = "Datadog WAF"
-  spec.description = <<-EOS.gsub(/^[\s]+/, "")
+  spec.description = <<-EOS.gsub(/^\s+/, "")
     libddwaf packages a WAF implementation in C++, exposed to Ruby
   EOS
 

--- a/spec/datadog/appsec/waf/converter_spec.rb
+++ b/spec/datadog/appsec/waf/converter_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
       end
 
       it "converts a symbol" do
-        obj = described_class.ruby_to_object(:foo)
+        obj = described_class.ruby_to_object(:foo, max_string_length: 10)
         expect(obj[:type]).to eq :ddwaf_obj_string
         expect(obj[:nbEntries]).to eq 3
         expect(obj[:valueUnion][:stringValue].read_bytes(obj[:nbEntries])).to eq "foo"
@@ -308,6 +308,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             obj = described_class.ruby_to_object({nil => :foo}, max_string_length: max_string_length)
             expect(obj[:type]).to eq(:ddwaf_obj_map)
             expect(obj[:nbEntries]).to eq(1)
+            expect(obj).not_to be_truncated
           end
         end
       end

--- a/spec/datadog/appsec/waf/converter_spec.rb
+++ b/spec/datadog/appsec/waf/converter_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
           end
 
           it "does not mark arrays within the limit as truncated" do
-            obj = described_class.ruby_to_object((1..3).to_a, max_container_size: 3)
+            obj = described_class.ruby_to_object([1, 2, 3].to_a, max_container_size: 3)
             expect(obj[:type]).to eq(:ddwaf_obj_array)
             expect(obj[:nbEntries]).to eq(3)
             expect(obj).not_to be_truncated

--- a/spec/datadog/appsec/waf/converter_spec.rb
+++ b/spec/datadog/appsec/waf/converter_spec.rb
@@ -303,6 +303,12 @@ RSpec.describe Datadog::AppSec::WAF::Converter do
             expect(k).to eq "fooooooooo"
             expect(obj).to be_truncated
           end
+
+          it "converts hash with a nil key" do
+            obj = described_class.ruby_to_object({nil => :foo}, max_string_length: max_string_length)
+            expect(obj[:type]).to eq(:ddwaf_obj_map)
+            expect(obj[:nbEntries]).to eq(1)
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #94

**What does this PR do?**
It fixes conversion for a Hash that has a `nil` key.

**Motivation**
https://github.com/DataDog/libddwaf-rb/issues/94
https://github.com/DataDog/dd-trace-rb/issues/4885

**Additional Notes**
None.

**How to test the change?**
CI should be enough.