### PR TITLE
Bump version to 1.24.1.2.1

### DIFF
--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -5,7 +5,7 @@ module Datadog
         BASE_STRING = "1.24.1"
         # NOTE: Every change to the `BASE_STRING` should be accompanied
         #       by a reset of the patch version in the `STRING` below.
-        STRING = "#{BASE_STRING}.2.0"
+        STRING = "#{BASE_STRING}.2.1"
         MINIMUM_RUBY_VERSION = "2.5"
       end
     end


### PR DESCRIPTION
**What does this PR do?**
It increases the version to 1.24.1.2.1.

**Motivation**
https://github.com/DataDog/libddwaf-rb/issues/94
https://github.com/DataDog/dd-trace-rb/issues/4885

**Additional Notes**
None.

**How to test the change?**
CI