### PR TITLE
[APPSEC-58893] Fix error handling of ddwaf_run call

### DIFF
--- a/lib/datadog/appsec/waf/converter.rb
+++ b/lib/datadog/appsec/waf/converter.rb
@@ -164,19 +164,19 @@ module Datadog
           when :ddwaf_obj_float
             obj[:valueUnion][:f64]
           when :ddwaf_obj_array
-            (0...obj[:nbEntries]).each.with_object([]) do |i, a|
+            (0...obj[:nbEntries]).each.with_object([]) do |i, a| #$ ::Array[WAF::output]
               ptr = obj[:valueUnion][:array] + i * LibDDWAF::Object.size
               e = Converter.object_to_ruby(LibDDWAF::Object.new(ptr))
-              a << e # steep:ignore
+              a << e
             end
           when :ddwaf_obj_map
-            (0...obj[:nbEntries]).each.with_object({}) do |i, h| #$ ::Hash[::String, WAF::data]
+            (0...obj[:nbEntries]).each.with_object({}) do |i, h| #$ ::Hash[::String, WAF::output]
               ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
               o = Datadog::AppSec::WAF::LibDDWAF::Object.new(ptr)
               l = o[:parameterNameLength]
               k = o[:parameterName].read_bytes(l)
               v = Converter.object_to_ruby(LibDDWAF::Object.new(ptr))
-              h[k] = v # steep:ignore
+              h[k] = v
             end
           end
         end

--- a/lib/datadog/appsec/waf/result.rb
+++ b/lib/datadog/appsec/waf/result.rb
@@ -14,8 +14,9 @@ module Datadog
           @actions = actions
           @attributes = attributes
           @duration = duration
-          @timeout = timeout
-          @keep = keep
+
+          @keep = !!keep
+          @timeout = !!timeout
           @input_truncated = false
         end
 
@@ -42,8 +43,8 @@ module Datadog
             actions: @actions,
             attributes: @attributes,
             duration: @duration,
-            timeout: @timeout,
             keep: @keep,
+            timeout: @timeout,
             input_truncated: @input_truncated
           }
         end

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -1,17 +1,20 @@
 module Datadog
   module AppSec
     module WAF
-      type data = nil | bool | ::String | ::Symbol | ::Integer | ::Float | ::Array[data] | ::Hash[(::String | ::Symbol | nil), data]
+      type input = nil | bool | ::String | ::Symbol | ::Integer | ::Float | ::Array[input] | ::Hash[input, input]
+      type output = nil | bool | ::String | ::Integer | ::Float | ::Array[output] | ::Hash[::String, output]
       type known_addresses = ::Array[::String]
-      type diagnostics = ::Hash[::String, untyped]
+
+      self.@logger: ::Logger
+
+      self.@log_callback: LibDDWAF::ddwaf_log_cb
 
       def self?.version: () -> ::String
 
-      self.@logger: ::Logger
-      self.@log_callback: LibDDWAF::ddwaf_log_cb
-
       def self?.log_callback: (LibDDWAF::ddwaf_log_level, ::String, ::String, ::Integer, ::FFI::Pointer, ::Integer) -> void
+
       def self?.logger: () -> ::Logger
+
       def self?.logger=: (::Logger logger) -> void
     end
   end

--- a/sig/datadog/appsec/waf/context.rbs
+++ b/sig/datadog/appsec/waf/context.rbs
@@ -4,15 +4,26 @@ module Datadog
       class Context
         @context_ptr: ::FFI::Pointer
 
-        @retained: Array[untyped]
+        @retained: Array[top]
 
-        RESULT_CODE: ::Hash[::Symbol, ::Symbol]
+        EMPTY_RESULT: {
+          "events" => ::Array[WAF::output],
+          "actions" => ::Hash[::String, WAF::output],
+          "attributes" => ::Hash[::String, WAF::output],
+          "duration" => ::Integer,
+          "timeout" => bool,
+          "keep" => bool
+        }
+
+        SUCCESS_RESULT_CODES: ::Array[::Symbol]
+
+        RESULT_CODE_TO_STATUS: ::Hash[::Symbol, ::Symbol]
 
         def initialize: (::FFI::Pointer context_ptr) -> void
 
         def finalize!: () -> void
 
-        def run: (WAF::data persistent_data, WAF::data ephemeral_data, ?::Integer timeout) -> Result
+        def run: (WAF::input persistent_data, WAF::input ephemeral_data, ?::Integer timeout) -> Result
 
         private
 

--- a/sig/datadog/appsec/waf/converter.rbs
+++ b/sig/datadog/appsec/waf/converter.rbs
@@ -2,9 +2,16 @@ module Datadog
   module AppSec
     module WAF
       module Converter
-        def self?.ruby_to_object: (top val, ?max_container_size: ::Integer?, ?max_container_depth: ::Integer?, ?max_string_length: ::Integer?, ?top_obj: LibDDWAF::Object?, ?coerce: bool?) -> LibDDWAF::Object
+        def self?.ruby_to_object: (
+          top val,
+          ?max_container_size: ::Integer?,
+          ?max_container_depth: ::Integer?,
+          ?max_string_length: ::Integer?,
+          ?top_obj: LibDDWAF::Object?,
+          ?coerce: bool?
+        ) -> LibDDWAF::Object
 
-        def self?.object_to_ruby: (LibDDWAF::Object obj) -> WAF::data
+        def self?.object_to_ruby: (LibDDWAF::Object obj) -> WAF::output
       end
     end
   end

--- a/sig/datadog/appsec/waf/errors.rbs
+++ b/sig/datadog/appsec/waf/errors.rbs
@@ -11,9 +11,9 @@ module Datadog
       end
 
       class LibDDWAFError < Error
-        attr_reader diagnostics: WAF::data
+        attr_reader diagnostics: WAF::output
 
-        def initialize: (::String msg, ?diagnostics: WAF::data?) -> void
+        def initialize: (::String msg, ?diagnostics: WAF::output?) -> void
       end
     end
   end

--- a/sig/datadog/appsec/waf/handle_builder.rbs
+++ b/sig/datadog/appsec/waf/handle_builder.rbs
@@ -10,7 +10,7 @@ module Datadog
 
         def build_handle: () -> Handle
 
-        def add_or_update_config: (data config, path: ::String) -> data
+        def add_or_update_config: (WAF::input config, path: ::String) -> WAF::output
 
         def remove_config_at_path: (::String path) -> bool
 

--- a/sig/datadog/appsec/waf/lib_ddwaf.rbs
+++ b/sig/datadog/appsec/waf/lib_ddwaf.rbs
@@ -58,6 +58,8 @@ module Datadog
         end
 
         class Object < ::FFI::Struct[::FFI::AbstractMemory, untyped]
+          @truncated: bool
+
           def truncated?: () -> bool
 
           def mark_truncated!: () -> bool

--- a/sig/datadog/appsec/waf/result.rbs
+++ b/sig/datadog/appsec/waf/result.rbs
@@ -2,13 +2,16 @@ module Datadog
   module AppSec
     module WAF
       class Result
+        type list = ::Array[WAF::output]
+        type map = ::Hash[::String, WAF::output]
+
         @status: ::Symbol
 
-        @events: WAF::data
+        @events: list
 
-        @actions: WAF::data
+        @actions: map
 
-        @attributes: WAF::data
+        @attributes: map
 
         @duration: ::Integer
 
@@ -20,19 +23,19 @@ module Datadog
 
         attr_reader status: ::Symbol
 
-        attr_reader events: WAF::data
+        attr_reader events: list
 
-        attr_reader actions: WAF::data
+        attr_reader actions: map
 
-        attr_reader attributes: WAF::data
+        attr_reader attributes: map
 
         attr_reader duration: ::Integer
 
         def initialize: (
           status: ::Symbol,
-          events: WAF::data,
-          actions: WAF::data,
-          attributes: WAF::data,
+          events: list,
+          actions: map,
+          attributes: map,
           duration: ::Integer,
           timeout: bool,
           keep: bool
@@ -46,7 +49,7 @@ module Datadog
 
         def input_truncated?: () -> bool
 
-        def to_h: () -> ::Hash[::Symbol, WAF::data]
+        def to_h: () -> ::Hash[::Symbol, (::Symbol | WAF::output)]
       end
     end
   end

--- a/spec/datadog/appsec/waf/context_spec.rb
+++ b/spec/datadog/appsec/waf/context_spec.rb
@@ -240,5 +240,28 @@ RSpec.describe Datadog::AppSec::WAF::Context do
         )
       end
     end
+
+    context "when result is an error" do
+      before do
+        allow(Datadog::AppSec::WAF::LibDDWAF).to receive(:ddwaf_run)
+          .and_return(:ddwaf_err_internal)
+      end
+
+      let(:result) { context.run({}, {}) }
+
+      it "returns empty result with an error status code" do
+        aggregate_failures("result") do
+          expect(result).not_to be_timeout
+          expect(result).not_to be_keep
+          expect(result).not_to be_input_truncated
+
+          expect(result.status).to eq(:err_internal)
+          expect(result.events).to eq([])
+          expect(result.actions).to eq({})
+          expect(result.attributes).to eq({})
+          expect(result.duration).to be_zero
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

This is a fix for conversion of an empty object when WAF run was not successful. 

**Motivation**

This was a hidden breaking change from `libddwaf` that we caught before the tracer update 

**Additional Notes**

I've refactored types and split it better in reusable type aliases. In addition I've fixed few minor mistakes of the past

**How to test the change?**

Should be CI