### PR TITLE
Explicitly define WAF result struct

### DIFF
--- a/lib/datadog/appsec/waf/context.rb
+++ b/lib/datadog/appsec/waf/context.rb
@@ -7,9 +7,9 @@ module Datadog
       # See https://github.com/DataDog/libddwaf/blob/10e3a1dfc7bc9bb8ab11a09a9f8b6b339eaf3271/BINDING_IMPL_NOTES.md?plain=1#L125-L158
       class Context
         EMPTY_RESULT = {
-          "events" => [],     #: ::Array[WAF::output]
-          "actions" => {},    #: ::Hash[::String, WAF::output]
-          "attributes" => {}, #: ::Hash[::String, WAF::output]
+          "events" => [],     #: WAF::events
+          "actions" => {},    #: WAF::actions
+          "attributes" => {}, #: WAF::attributes
           "duration" => 0,
           "timeout" => false,
           "keep" => false

--- a/lib/datadog/appsec/waf/converter.rb
+++ b/lib/datadog/appsec/waf/converter.rb
@@ -164,13 +164,13 @@ module Datadog
           when :ddwaf_obj_float
             obj[:valueUnion][:f64]
           when :ddwaf_obj_array
-            (0...obj[:nbEntries]).each.with_object([]) do |i, a| #$ ::Array[WAF::output]
+            (0...obj[:nbEntries]).each.with_object([]) do |i, a| #$ ::Array[WAF::opaque]
               ptr = obj[:valueUnion][:array] + i * LibDDWAF::Object.size
               e = Converter.object_to_ruby(LibDDWAF::Object.new(ptr))
               a << e
             end
           when :ddwaf_obj_map
-            (0...obj[:nbEntries]).each.with_object({}) do |i, h| #$ ::Hash[::String, WAF::output]
+            (0...obj[:nbEntries]).each.with_object({}) do |i, h| #$ ::Hash[::String, WAF::opaque]
               ptr = obj[:valueUnion][:array] + i * Datadog::AppSec::WAF::LibDDWAF::Object.size
               o = Datadog::AppSec::WAF::LibDDWAF::Object.new(ptr)
               l = o[:parameterNameLength]

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -2,8 +2,45 @@ module Datadog
   module AppSec
     module WAF
       type input = nil | bool | ::String | ::Symbol | ::Integer | ::Float | ::Array[input] | ::Hash[input, input]
-      type output = nil | bool | ::String | ::Integer | ::Float | ::Array[output] | ::Hash[::String, output]
       type known_addresses = ::Array[::String]
+      type result = {
+        "keep" => bool,
+        "events" => events,
+        "actions" => actions,
+        "attributes" => attributes,
+        "timeout" => bool,
+        # NOTE: Schema defines it as a `number`, but we alway get it as `Integer`
+        #       That will be fixed in the libddwaf specs
+        "duration" => ::Integer
+      }
+      type events = ::Array[event]
+      type event = {"rule" => rule, "rule_matches" => ::Array[rule_match]}
+      type rule = {
+        "id" => ::String,
+        "name" => ::String,
+        "tags" => {
+          "type" => ::String,
+          # optional key
+          "category" => ::String?
+        },
+        # optional key
+        "on_match" => ::Array[::String]?
+      }
+      type rule_match = {
+        "operator" => ::String,
+        "operator_value" => ::String,
+        "parameters" => ::Array[rule_match_parameter]
+      }
+      type rule_match_parameter = {
+        "address" => ::String,
+        "key_path" => ::Array[::String | ::Integer],
+        "value" => ::String,
+        "highlight" => ::Array[::String]
+      }
+      type actions = ::Hash[::String, action]
+      type action = ::Hash[::String, ::String]
+      type attributes = ::Hash[::String, opaque]
+      type opaque = nil | bool | ::String | ::Integer | ::Float | ::Array[opaque] | ::Hash[::String, opaque]
 
       self.@logger: ::Logger
 

--- a/sig/datadog/appsec/waf/context.rbs
+++ b/sig/datadog/appsec/waf/context.rbs
@@ -4,12 +4,12 @@ module Datadog
       class Context
         @context_ptr: ::FFI::Pointer
 
-        @retained: Array[top]
+        @retained: Array[untyped]
 
         EMPTY_RESULT: {
-          "events" => ::Array[WAF::output],
-          "actions" => ::Hash[::String, WAF::output],
-          "attributes" => ::Hash[::String, WAF::output],
+          "events" => WAF::events,
+          "actions" => WAF::actions,
+          "attributes" => WAF::attributes,
           "duration" => ::Integer,
           "timeout" => bool,
           "keep" => bool

--- a/sig/datadog/appsec/waf/converter.rbs
+++ b/sig/datadog/appsec/waf/converter.rbs
@@ -11,7 +11,7 @@ module Datadog
           ?coerce: bool?
         ) -> LibDDWAF::Object
 
-        def self?.object_to_ruby: (LibDDWAF::Object obj) -> WAF::output
+        def self?.object_to_ruby: (LibDDWAF::Object obj) -> WAF::opaque
       end
     end
   end

--- a/sig/datadog/appsec/waf/errors.rbs
+++ b/sig/datadog/appsec/waf/errors.rbs
@@ -11,9 +11,9 @@ module Datadog
       end
 
       class LibDDWAFError < Error
-        attr_reader diagnostics: WAF::output
+        attr_reader diagnostics: WAF::opaque
 
-        def initialize: (::String msg, ?diagnostics: WAF::output?) -> void
+        def initialize: (::String msg, ?diagnostics: WAF::opaque?) -> void
       end
     end
   end

--- a/sig/datadog/appsec/waf/handle_builder.rbs
+++ b/sig/datadog/appsec/waf/handle_builder.rbs
@@ -10,7 +10,7 @@ module Datadog
 
         def build_handle: () -> Handle
 
-        def add_or_update_config: (WAF::input config, path: ::String) -> WAF::output
+        def add_or_update_config: (WAF::input config, path: ::String) -> WAF::opaque
 
         def remove_config_at_path: (::String path) -> bool
 

--- a/sig/datadog/appsec/waf/result.rbs
+++ b/sig/datadog/appsec/waf/result.rbs
@@ -2,16 +2,13 @@ module Datadog
   module AppSec
     module WAF
       class Result
-        type list = ::Array[WAF::output]
-        type map = ::Hash[::String, WAF::output]
-
         @status: ::Symbol
 
-        @events: list
+        @events: WAF::events
 
-        @actions: map
+        @actions: WAF::actions
 
-        @attributes: map
+        @attributes: WAF::attributes
 
         @duration: ::Integer
 
@@ -23,19 +20,19 @@ module Datadog
 
         attr_reader status: ::Symbol
 
-        attr_reader events: list
+        attr_reader events: WAF::events
 
-        attr_reader actions: map
+        attr_reader actions: WAF::actions
 
-        attr_reader attributes: map
+        attr_reader attributes: WAF::attributes
 
         attr_reader duration: ::Integer
 
         def initialize: (
           status: ::Symbol,
-          events: list,
-          actions: map,
-          attributes: map,
+          events: WAF::events,
+          actions: WAF::actions,
+          attributes: WAF::attributes,
           duration: ::Integer,
           timeout: bool,
           keep: bool
@@ -49,7 +46,7 @@ module Datadog
 
         def input_truncated?: () -> bool
 
-        def to_h: () -> ::Hash[::Symbol, (::Symbol | WAF::output)]
+        def to_h: () -> ::Hash[::Symbol, (::Symbol | WAF::opaque)]
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

Defines WAF type `result` with all the existing known specs from the [`libddwaf`](https://github.com/DataDog/libddwaf/blob/master/schema/result.json)

**Motivation**

This is a contract definition for us to follow on libddwaf upgrade.

**Additional Notes**

The upstream still require some improvements over existing schemas.

**How to test the change?**

Just type checker