### PR TITLE
[APPSEC-59241] Fix ruleset primitives coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# 2025-09-24 v1.25.1.1.0
+
+## Changed
+
+- Change coersion of the values in WAF rules to use `libddwaf` primitives
+
 # 2025-09-18 v1.25.1.0.1
 
 ## Fixed

--- a/lib/datadog/appsec/waf/handle_builder.rb
+++ b/lib/datadog/appsec/waf/handle_builder.rb
@@ -58,7 +58,7 @@ module Datadog
         def add_or_update_config(config, path:)
           ensure_pointer_presence!
 
-          config_obj = Converter.ruby_to_object(config)
+          config_obj = Converter.ruby_to_object(config, coerce: false)
           diagnostics_obj = LibDDWAF::Object.new
 
           LibDDWAF.ddwaf_builder_add_or_update_config(@builder_ptr, path, path.length, config_obj, diagnostics_obj)

--- a/lib/datadog/appsec/waf/version.rb
+++ b/lib/datadog/appsec/waf/version.rb
@@ -5,7 +5,7 @@ module Datadog
         BASE_STRING = "1.25.1"
         # NOTE: Every change to the `BASE_STRING` should be accompanied
         #       by a reset of the patch version in the `STRING` below.
-        STRING = "#{BASE_STRING}.0.1"
+        STRING = "#{BASE_STRING}.1.0"
         MINIMUM_RUBY_VERSION = "2.5"
       end
     end

--- a/spec/datadog/appsec/waf/handle_builder_spec.rb
+++ b/spec/datadog/appsec/waf/handle_builder_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe Datadog::AppSec::WAF::HandleBuilder do
         expect(diagnostics.dig("rules", "loaded")).to eq(["rasp-003-001"])
         expect(diagnostics.dig("rules", "errors")).to be_empty
 
+        expect(diagnostics).to have_key("rules_compat")
+        expect(diagnostics.dig("rules_compat", "loaded")).to eq(["ttr-000-001"])
+        expect(diagnostics.dig("rules_compat", "errors")).to be_empty
+
         expect(diagnostics).to have_key("actions")
         expect(diagnostics.dig("actions", "loaded")).to eq(["block-sqli"])
         expect(diagnostics.dig("actions", "errors")).to be_empty

--- a/spec/datadog/appsec/waf/handle_spec.rb
+++ b/spec/datadog/appsec/waf/handle_spec.rb
@@ -31,7 +31,12 @@ RSpec.describe Datadog::AppSec::WAF::Handle do
 
   describe "#known_addresses" do
     it "returns a list of known addresses based on loaded rules" do
-      expect(handle.known_addresses).to match_array(["server.request.query", "server.db.statement", "server.db.system"])
+      expect(handle.known_addresses).to match_array([
+        "server.request.query",
+        "server.db.statement",
+        "server.db.system",
+        "server.request.headers.no_cookies"
+      ])
     end
 
     it "calls libddwaf once and memoizes the result" do

--- a/spec/fixtures/valid_config.json
+++ b/spec/fixtures/valid_config.json
@@ -25,6 +25,43 @@
       "on_match": ["block-sqli"]
     }
   ],
+  "rules_compat": [
+    {
+      "id": "ttr-000-001",
+      "name": "Trace Tagging",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": ["user-agent"]
+              }
+            ],
+            "regex": "^TraceTagging/v1"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "output": {
+        "event": true,
+        "keep": true,
+        "attributes": {
+          "some.arbitrary.string.value": { "value": "bad user agent" },
+          "some.arbitrary.number.value": { "value": 662607015 },
+          "some.arbitrary.compute.value": {
+            "address": "server.request.headers.no_cookies",
+            "key_path": ["user-agent"]
+          }
+        }
+      },
+      "on_match": []
+    }
+  ],
   "actions": [
     {
       "id": "block-sqli",


### PR DESCRIPTION
**What does this PR do?**

Disable coercion of some primitives into strings for rulesets

**Motivation**

New rulesets require now values like numbers to be distinguished from strings.

**Additional Notes**

I would like to release it as minor patch instead of fix patch to reduce possible blast radius.

**How to test the change?**

CI